### PR TITLE
add seq_id to recorder events

### DIFF
--- a/hyper/src/commands/show.rs
+++ b/hyper/src/commands/show.rs
@@ -154,7 +154,13 @@ impl ShowCommand {
                         .collect();
                     let dt: DateTime<Local> = event.time.into();
 
-                    write!(tw, "{}\t{}\n", dt, serde_json::to_string(&map)?)?;
+                    write!(
+                        tw,
+                        "{}\t{:8}\t{}\n",
+                        dt,
+                        event.seq,
+                        serde_json::to_string(&map)?
+                    )?;
                 }
                 write!(tw, "spans:\n")?;
                 for spans in tree.spans.iter() {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -143,6 +143,8 @@ pub struct Event {
     pub time: SystemTime,
     /// The payload of the event.
     pub fields: Vec<(String, recorder::Value)>,
+    /// The sequence number of the event.
+    pub seq: usize,
 }
 
 impl From<recorder::Event> for Event {
@@ -150,6 +152,7 @@ impl From<recorder::Event> for Event {
         Event {
             time: event.time,
             fields: event.fields(),
+            seq: event.seq,
         }
     }
 }


### PR DESCRIPTION
Summary:
Added a `seq_id` field to recorder events. This `seq_id` always increments by 1.
The purpose of the `seq_id` is to help us
1. dedupe messages in logs
2. identify holes and hole sizes in the logs

Differential Revision: D74884631


