### PR TITLE
Add `Castable` macro

### DIFF
--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -106,6 +106,8 @@ pub use cityhasher;
 pub use dashmap; // For intern_typename!
 pub use data::Named;
 #[doc(inline)]
+pub use hyperactor_macros::Bind;
+#[doc(inline)]
 pub use hyperactor_macros::HandleClient;
 #[doc(inline)]
 pub use hyperactor_macros::Handler;
@@ -113,6 +115,8 @@ pub use hyperactor_macros::Handler;
 pub use hyperactor_macros::Named;
 #[doc(inline)]
 pub use hyperactor_macros::RefClient;
+#[doc(inline)]
+pub use hyperactor_macros::Unbind;
 #[doc(inline)]
 pub use hyperactor_macros::export;
 #[doc(inline)]

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -313,6 +313,8 @@ mod tests {
     use hyperactor::id;
 
     use super::*;
+    use crate::Bind;
+    use crate::Unbind;
     use crate::accum::ReducerSpec;
     use crate::reference::UnboundPort;
 
@@ -321,30 +323,14 @@ mod tests {
     struct MyReply(String);
 
     // Used to demonstrate a two-way message type.
-    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named)]
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named, Bind, Unbind)]
     struct MyMessage {
         arg0: bool,
         arg1: u32,
+        #[binding(include)]
         reply0: PortRef<String>,
+        #[binding(include)]
         reply1: PortRef<MyReply>,
-    }
-
-    // TODO(pzhang) add macro to auto-gen this implementation.
-    impl Unbind for MyMessage {
-        fn unbind(&self, bindings: &mut Bindings) -> anyhow::Result<()> {
-            self.reply0.unbind(bindings)?;
-            self.reply1.unbind(bindings)?;
-            Ok(())
-        }
-    }
-
-    // TODO(pzhang) add macro to auto-gen this implementation.
-    impl Bind for MyMessage {
-        fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
-            self.reply0.bind(bindings)?;
-            self.reply1.bind(bindings)?;
-            Ok(())
-        }
     }
 
     #[test]

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -838,11 +838,6 @@ impl<M: RemoteMessage> PortRef<M> {
         &self.port_id
     }
 
-    /// Mutable reference to this port's ID.
-    pub fn port_id_mut(&mut self) -> &mut PortId {
-        &mut self.port_id
-    }
-
     /// Convert this PortRef into its corresponding port id.
     pub fn into_port_id(self) -> PortId {
         self.port_id

--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -7,6 +7,7 @@
  */
 
 #![allow(dead_code)]
+pub mod castable;
 pub mod export;
 
 use std::fmt::Debug;

--- a/hyperactor_macros/tests/castable.rs
+++ b/hyperactor_macros/tests/castable.rs
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#![allow(dead_code)]
+
+use hyperactor::Bind;
+use hyperactor::Named;
+use hyperactor::PortRef;
+use hyperactor::Unbind;
+use serde::Deserialize;
+use serde::Serialize;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Named)]
+struct MyReply(String);
+
+#[derive(Clone, Debug, PartialEq, Bind, Unbind)]
+struct MyNamedStruct {
+    field0: u64,
+    field1: MyReply,
+    #[binding(include)]
+    field2: PortRef<MyReply>,
+    field3: bool,
+    #[binding(include)]
+    field4: hyperactor::PortRef<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Bind, Unbind)]
+struct MyUnamedStruct(
+    u64,
+    MyReply,
+    #[binding(include)] hyperactor::PortRef<MyReply>,
+    bool,
+    #[binding(include)] PortRef<u64>,
+);
+
+#[derive(Clone, Debug, PartialEq, Bind, Unbind)]
+enum MyEnum {
+    Unit,
+    NoopTuple(u64, bool),
+    NoopStruct {
+        field0: u64,
+        field1: bool,
+    },
+    Tuple(
+        u64,
+        MyReply,
+        #[binding(include)] PortRef<MyReply>,
+        bool,
+        #[binding(include)] hyperactor::PortRef<u64>,
+    ),
+    Struct {
+        field0: u64,
+        field1: MyReply,
+        #[binding(include)]
+        field2: PortRef<MyReply>,
+        field3: bool,
+        #[binding(include)]
+        field4: hyperactor::PortRef<u64>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+
+    use hyperactor::id;
+    use hyperactor::message::Bind;
+    use hyperactor::message::Bindings;
+    use hyperactor::message::Unbind;
+    use hyperactor::message::Unbound;
+
+    use super::*;
+
+    fn verify<T: Bind + Unbind + Clone + PartialEq + Debug>(my_type: T, bindings: Bindings) {
+        let unbound = Unbound::try_from_message(my_type.clone()).unwrap();
+
+        assert_eq!(unbound, Unbound::new(my_type.clone(), bindings));
+
+        let bind = unbound.bind().unwrap();
+        assert_eq!(bind, my_type);
+    }
+
+    #[test]
+    fn test_named_struct() {
+        let port_id2 = id!(world[0].comm[0][2]);
+        let port_id4 = id!(world[1].worker[0][4]);
+        let port2 = PortRef::attest(port_id2.clone());
+        let port4 = PortRef::attest(port_id4.clone());
+        let my_struct = MyNamedStruct {
+            field0: 11,
+            field1: MyReply("hello".to_string()),
+            field2: port2.clone(),
+            field3: true,
+            field4: port4.clone(),
+        };
+        let mut bindings = Bindings::default();
+        port2.unbind(&mut bindings).unwrap();
+        port4.unbind(&mut bindings).unwrap();
+        verify(my_struct, bindings);
+    }
+
+    #[test]
+    fn test_unnamed_struct() {
+        let port_id2 = id!(world[0].comm[0][2]);
+        let port_id4 = id!(world[1].worker[0][4]);
+        let port2 = PortRef::attest(port_id2.clone());
+        let port4 = PortRef::attest(port_id4.clone());
+        let my_struct = MyUnamedStruct(
+            11,
+            MyReply("hello".to_string()),
+            port2.clone(),
+            true,
+            port4.clone(),
+        );
+        let mut bindings = Bindings::default();
+        port2.unbind(&mut bindings).unwrap();
+        port4.unbind(&mut bindings).unwrap();
+        verify(my_struct, bindings);
+    }
+
+    #[test]
+    fn test_named_enum() {
+        let port_id2 = id!(world[0].comm[0][2]);
+        let port_id4 = id!(world[1].worker[0][4]);
+        let port2 = PortRef::attest(port_id2.clone());
+        let port4 = PortRef::attest(port_id4.clone());
+        let my_enum = MyEnum::Struct {
+            field0: 11,
+            field1: MyReply("hello".to_string()),
+            field2: port2.clone(),
+            field3: true,
+            field4: port4.clone(),
+        };
+        let mut bindings = Bindings::default();
+        port2.unbind(&mut bindings).unwrap();
+        port4.unbind(&mut bindings).unwrap();
+        verify(my_enum, bindings);
+    }
+
+    #[test]
+    fn test_unnamed_enum() {
+        let port_id2 = id!(world[0].comm[0][2]);
+        let port_id4 = id!(world[1].worker[0][4]);
+        let port2 = PortRef::attest(port_id2.clone());
+        let port4 = PortRef::attest(port_id4.clone());
+        let my_enum = MyEnum::Tuple(
+            11,
+            MyReply("hello".to_string()),
+            port2.clone(),
+            true,
+            port4.clone(),
+        );
+        let mut bindings = Bindings::default();
+        port2.unbind(&mut bindings).unwrap();
+        port4.unbind(&mut bindings).unwrap();
+        verify(my_enum, bindings);
+    }
+
+    #[test]
+    fn test_unit_enum() {
+        let my_enum = MyEnum::Unit;
+        let bindings = Bindings::default();
+        verify(my_enum, bindings);
+    }
+}

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -14,14 +14,13 @@ use std::process::ExitCode;
 use anyhow::Result;
 use async_trait::async_trait;
 use hyperactor::Actor;
+use hyperactor::Bind;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::PortRef;
-use hyperactor::message::Bind;
-use hyperactor::message::Bindings;
+use hyperactor::Unbind;
 use hyperactor::message::IndexedErasedUnbound;
-use hyperactor::message::Unbind;
 use hyperactor_mesh::ProcMesh;
 use hyperactor_mesh::actor_mesh::ActorMesh;
 use hyperactor_mesh::actor_mesh::Cast;
@@ -66,29 +65,10 @@ struct PhilosopherActor {
 }
 
 /// Message from the waiter to a philosopher
-#[derive(Debug, Serialize, Deserialize, Named, Clone)]
+#[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
 enum PhilosopherMessage {
-    Start(PortRef<WaiterMessage>),
+    Start(#[binding(include)] PortRef<WaiterMessage>),
     GrantChopstick(usize),
-}
-
-// TODO(pzhang) replace the boilerplate Bind/Unbind impls with a macro.
-impl Bind for PhilosopherMessage {
-    fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
-        match self {
-            Self::Start(port) => port.bind(bindings),
-            Self::GrantChopstick(_) => Ok(()),
-        }
-    }
-}
-
-impl Unbind for PhilosopherMessage {
-    fn unbind(&self, bindings: &mut Bindings) -> anyhow::Result<()> {
-        match self {
-            Self::Start(port) => port.unbind(bindings),
-            Self::GrantChopstick(_) => Ok(()),
-        }
-    }
 }
 
 /// Message from a philosopher to the waiter

--- a/hyperactor_mesh/src/test_utils.rs
+++ b/hyperactor_mesh/src/test_utils.rs
@@ -8,34 +8,20 @@
 
 use async_trait::async_trait;
 use hyperactor::Actor;
+use hyperactor::Bind;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::Named;
-use hyperactor::message::Bind;
-use hyperactor::message::Bindings;
+use hyperactor::Unbind;
 use hyperactor::message::IndexedErasedUnbound;
-use hyperactor::message::Unbind;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate::actor_mesh::Cast;
 
 /// Message that can be sent to an EmptyActor.
-#[derive(Serialize, Deserialize, Debug, Named, Clone)]
+#[derive(Serialize, Deserialize, Debug, Named, Clone, Bind, Unbind)]
 pub struct EmptyMessage();
-
-// TODO(pzhang) replace the boilerplate Bind/Unbind impls with a macro.
-impl Bind for EmptyMessage {
-    fn bind(&mut self, _bindings: &mut Bindings) -> anyhow::Result<()> {
-        Ok(())
-    }
-}
-
-impl Unbind for EmptyMessage {
-    fn unbind(&self, _bindings: &mut Bindings) -> anyhow::Result<()> {
-        Ok(())
-    }
-}
 
 /// No-op actor.
 #[derive(Debug, PartialEq)]

--- a/monarch_messages/src/worker.rs
+++ b/monarch_messages/src/worker.rs
@@ -20,14 +20,13 @@ use derive_more::From;
 use derive_more::TryInto;
 use enum_as_inner::EnumAsInner;
 use hyperactor::ActorRef;
+use hyperactor::Bind;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Named;
 use hyperactor::RefClient;
-use hyperactor::message::Bind;
-use hyperactor::message::Bindings;
+use hyperactor::Unbind;
 use hyperactor::message::IndexedErasedUnbound;
-use hyperactor::message::Unbind;
 use hyperactor::reference::ActorId;
 use monarch_types::SerializablePyErr;
 use ndslice::Slice;
@@ -564,7 +563,9 @@ impl From<Arc<CallFunctionError>> for ValueError {
     Deserialize,
     Debug,
     Named,
-    EnumAsInner
+    EnumAsInner,
+    Bind,
+    Unbind
 )]
 pub enum WorkerMessage {
     /// Initialize backend network state.
@@ -840,20 +841,6 @@ pub enum WorkerMessage {
         #[reply]
         response_port: hyperactor::OncePortRef<Option<Result<WireValue, ValueError>>>,
     },
-}
-
-// WorkerMessage currently has no accumulation reply port.
-// TODO(pzhang) add macro to auto implement these traits.
-impl Unbind for WorkerMessage {
-    fn unbind(&self, _bindings: &mut Bindings) -> anyhow::Result<()> {
-        Ok(())
-    }
-}
-
-impl Bind for WorkerMessage {
-    fn bind(&mut self, _bindings: &mut Bindings) -> anyhow::Result<()> {
-        Ok(())
-    }
 }
 
 /// The parameters to spawn a worker actor.

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -56,16 +56,15 @@ use device_mesh::DeviceMesh;
 use futures::future::try_join_all;
 use hyperactor::Actor;
 use hyperactor::ActorRef;
+use hyperactor::Bind;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::Named;
+use hyperactor::Unbind;
 use hyperactor::actor::ActorHandle;
 use hyperactor::cap;
 use hyperactor::forward;
-use hyperactor::message::Bind;
-use hyperactor::message::Bindings;
 use hyperactor::message::IndexedErasedUnbound;
-use hyperactor::message::Unbind;
 use hyperactor::reference::ActorId;
 use hyperactor_mesh::actor_mesh::Cast;
 use itertools::Itertools;
@@ -287,22 +286,9 @@ impl Handler<Cast<AssignRankMessage>> for WorkerActor {
 
 /// Worker messages. These define the observable behavior of the worker, so the
 /// documentations here
-#[derive(Handler, Clone, Serialize, Deserialize, Debug, Named)]
+#[derive(Handler, Clone, Serialize, Deserialize, Debug, Named, Bind, Unbind)]
 pub enum AssignRankMessage {
     AssignRank(),
-}
-
-// TODO(pzhang) replace the boilerplate Bind/Unbind impls with a macro.
-impl Bind for AssignRankMessage {
-    fn bind(&mut self, _bindings: &mut Bindings) -> anyhow::Result<()> {
-        Ok(())
-    }
-}
-
-impl Unbind for AssignRankMessage {
-    fn unbind(&self, _bindings: &mut Bindings) -> anyhow::Result<()> {
-        Ok(())
-    }
 }
 
 #[async_trait]


### PR DESCRIPTION
Summary:
This diff adds a `Castable` derive marco. This macro implements `trait Bind` and `trait Unbind` for the applied struct/enum.

Right now this macro only supports the `PortRef` type. We could extend it to support arbitrary types once we have such need.

The expanded code is shown in [this example](https://www.internalfb.com/code/fbsource/[3e39cd9e454d0d144b591b0674c171a4ea09b5b7]/fbcode/monarch/hyperactor_macros/derive_expanded.rs).

Differential Revision: D75322219


