### PR TITLE
: channel: fix lints

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -28,7 +28,6 @@ use std::mem::take;
 use std::net::ToSocketAddrs;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::OnceLock;
 use std::task::Poll;
 
 use backoff::ExponentialBackoffBuilder;
@@ -2134,7 +2133,7 @@ mod tests {
             if self.fail_connects.load(Ordering::Acquire) {
                 return Err(ClientError::Connect(
                     self.dest(),
-                    std::io::Error::new(io::ErrorKind::Other, "intentional error"),
+                    std::io::Error::other("intentional error"),
                     "expected failure injected by the mock".to_string(),
                 ));
             }

--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -230,10 +230,12 @@ mod tests {
     #[test]
     fn test_merge() {
         let mut config1 = Config::default();
-        let mut config2 = Config::default();
+        let config2 = Config {
+            codec_max_frame_length: 1024,
+            message_delivery_timeout: Duration::from_secs(60),
+            ..Config::default()
+        };
 
-        config2.codec_max_frame_length = 1024;
-        config2.message_delivery_timeout = Duration::from_secs(60);
         config1.merge(&config2);
 
         assert_eq!(config1.codec_max_frame_length, 1024);
@@ -245,9 +247,10 @@ mod tests {
         assert_eq!(global::codec_max_frame_length(), 8 * 1024 * 1024);
 
         // Temporarily modify the configuration using the legacy function
-        let mut temp_config = Config::default();
-        temp_config.codec_max_frame_length = 1024;
-
+        let temp_config = Config {
+            codec_max_frame_length: 1024,
+            ..Config::default()
+        };
         {
             let _guard = global::set_temp_config(temp_config.clone());
             assert_eq!(global::codec_max_frame_length(), 1024);

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -561,6 +561,7 @@ impl World {
         world_id.name().starts_with(SHADOW_PREFIX)
     }
 
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `CastError`.
     fn get_port_ref_from_host(
         &self,
         host_id: &HostId,
@@ -574,6 +575,7 @@ impl World {
     }
 
     /// Adds procs to the world.
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SystemActorError`.
     fn add_proc(
         &mut self,
         proc_id: ProcId,
@@ -639,6 +641,7 @@ impl World {
         Ok(())
     }
 
+    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SystemActorError`.
     fn get_hosts_to_procs(&mut self) -> Result<HashMap<HostId, Vec<ProcId>>, SystemActorError> {
         // A map from host ID to scheduled proc IDs on this host.
         let mut host_proc_map: HashMap<HostId, Vec<ProcId>> = HashMap::new();

--- a/ndslice/src/selection/mod.rs
+++ b/ndslice/src/selection/mod.rs
@@ -1041,14 +1041,14 @@ mod iterutils {
 /// # Example
 ///
 /// ```
-///  use ndslice::shape;
-///  use ndslice::selection::selection_from_one;
-//
+/// use ndslice::shape;
+/// use ndslice::selection::selection_from_one;
+///
 /// let shape = shape!(zone = 2, host = 4, gpu = 8);
 /// let sel = selection_from_one(&shape, "host", 1..3).unwrap();
 /// assert_eq!(format!("{sel:?}"), "All(Range(Range(1, Some(3), 1), True))"); // corresponds to (*, 1..3, *)
 /// ```
-/// --
+///
 /// [`all`]: crate::selection::dsl::all
 /// [`Shape`]: crate::shape::Shape
 /// [`Selection`]: crate::selection::Selection
@@ -1098,14 +1098,17 @@ where
 /// # Example
 ///
 /// ```
-///  use ndslice::shape;
-///  use ndslice::selection::selection_from;
-//
+/// use ndslice::selection::selection_from;
+/// use ndslice::shape;
+///
 /// let shape = shape!(zone = 2, host = 4, gpu = 8);
 /// let sel = selection_from(&shape, &[("host", 1..3), ("gpu", 0..4)]).unwrap();
-/// assert_eq!(format!("{sel:?}"), "All(Range(Range(1, Some(3), 1), Range(Range(0, Some(4), 1), True)))");
+/// assert_eq!(
+///     format!("{sel:?}"),
+///     "All(Range(Range(1, Some(3), 1), Range(Range(0, Some(4), 1), True)))"
+/// );
 /// ```
-/// --
+///
 /// [`Shape`]: crate::shape::Shape
 /// [`Selection`]: crate::selection::Selection
 /// [`all`]: crate::selection::dsl::all


### PR DESCRIPTION
Summary: fix lints in `hyperactor::channel::net`: remove unused import, use `std::io::Error::other`

Differential Revision: D75702690


