### PR TITLE
use multi-gpu machine on GH

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - name: 4xlarge
-            runs-on: linux.g5.4xlarge.nvidia.gpu
+            runs-on: linux.g5.12xlarge.nvidia.gpu
             torch-spec: '--pre torch --index-url https://download.pytorch.org/whl/nightly/cu126'
             gpu-arch-type: "cuda"
             gpu-arch-version: "12.6"


### PR DESCRIPTION
Summary: linux.g5.12xlarge.nvidia.gpu should have 4 GPUs, let's try this out

Differential Revision: D75702607


