### PR TITLE
service: only generate supervision events when there is no caller to which exceptions can be delivered

### DIFF
--- a/python/monarch/service.py
+++ b/python/monarch/service.py
@@ -493,9 +493,13 @@ class _Actor:
         except Exception as e:
             traceback.print_exc()
             s = ServiceCallFailedException(e)
+
+            # The exception is delivered to exactly one of:
+            # (1) our caller, (2) our supervisor
             if port is not None:
                 port.send("exception", s)
-            raise s from None
+            else:
+                raise s from None
 
     async def run_async(self, ctx, coroutine):
         _context.set(ctx)


### PR DESCRIPTION
Summary: We should deliver errors to exactly one receiver. This changes call semantics so that when there is a reply port, exceptions are delivered only thence; otherwise, we generate a supervision event by re-throwing the exception.

Differential Revision: D75706888


