### PR TITLE
Handle supervision events on work error

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -991,6 +991,9 @@ impl<A: Actor> Instance<A> {
                     let _ = MESSAGE_HANDLER_DURATION.start(metric_pairs);
                     let work = work.expect("inconsistent work queue state");
                     if let Err(err) = work.handle(actor, self).await {
+                        for supervision_event in self.supervision_event_receiver.drain() {
+                            self.handle_supervision_event(actor, supervision_event).await;
+                        }
                         return Err(ActorError::new(self.self_id().clone(), ActorErrorKind::Processing(err)));
                     }
                 }
@@ -1012,23 +1015,7 @@ impl<A: Actor> Instance<A> {
                     }
                 }
                 Ok(supervision_event) = self.supervision_event_receiver.recv() => {
-                    // Handle the supervision event with the current actor.
-                    if let Ok(false) = actor.handle_supervision_event(self, &supervision_event).await {
-                        // The supervision event wasn't handled by this actor, try to bubble it up.
-                        let result = self.cell.get_parent_cell();
-                        if let Some(parent) = result {
-                            parent
-                                .send_supervision_event_or_crash(supervision_event);
-                        } else {
-                            // Reaching here means the actor is either a root actor, or an orphaned
-                            // child actor (i.e. the parent actor was dropped unexpectedly). In either
-                            // case, the supervision event should be sent to proc.
-                            //
-                            // Note that orphaned actor is unexpected and would only happen if there
-                            // is a bug.
-                            self.proc.handle_supervision_event(supervision_event);
-                        }
-                    }
+                    self.handle_supervision_event(actor, supervision_event).await;
                 }
             }
             self.cell
@@ -1054,6 +1041,32 @@ impl<A: Actor> Instance<A> {
         tracing::debug!("exited actor loop");
         self.change_status(ActorStatus::Stopped);
         Ok(())
+    }
+
+    async fn handle_supervision_event(
+        &self,
+        actor: &mut A,
+        supervision_event: ActorSupervisionEvent,
+    ) {
+        // Handle the supervision event with the current actor.
+        if let Ok(false) = actor
+            .handle_supervision_event(self, &supervision_event)
+            .await
+        {
+            // The supervision event wasn't handled by this actor, try to bubble it up.
+            let result = self.cell.get_parent_cell();
+            if let Some(parent) = result {
+                parent.send_supervision_event_or_crash(supervision_event);
+            } else {
+                // Reaching here means the actor is either a root actor, or an orphaned
+                // child actor (i.e. the parent actor was dropped unexpectedly). In either
+                // case, the supervision event should be sent to proc.
+                //
+                // Note that orphaned actor is unexpected and would only happen if there
+                // is a bug.
+                self.proc.handle_supervision_event(supervision_event);
+            }
+        }
     }
 
     async unsafe fn handle_message<M: Message>(

--- a/hyperactor_multiprocess/src/proc_actor.rs
+++ b/hyperactor_multiprocess/src/proc_actor.rs
@@ -683,7 +683,7 @@ impl ProcMessageHandler for ProcActor {
             proc_id: self.params.proc.proc_id().clone(),
             proc_addr: self.params.local_addr.clone(),
             proc_health: ProcStatus::Alive,
-            failed_actors: HashMap::new(),
+            failed_actors: Vec::new(),
         };
 
         match tokio::time::timeout(
@@ -790,7 +790,7 @@ impl Handler<ActorSupervisionEvent> for ProcActor {
             proc_id: self.params.proc.proc_id().clone(),
             proc_addr: self.params.local_addr.clone(),
             proc_health: ProcStatus::Alive,
-            failed_actors: HashMap::from([event.into_inner()]),
+            failed_actors: Vec::from([event.into_inner()]),
         };
         self.params
             .supervisor_actor_ref
@@ -1214,7 +1214,7 @@ mod tests {
                         proc_addr: ChannelAddr::Local(3),
                         proc_id: local_proc_id.clone(),
                         proc_health: ProcStatus::Alive,
-                        failed_actors: HashMap::new(),
+                        failed_actors: Vec::new(),
                     }
                 );
                 let _ = port.send(&supervisor_mailbox, ());
@@ -1237,20 +1237,23 @@ mod tests {
         // Since we could get messages from both the periodic task and the
         // report from the failed actor, we need to poll for a while to make
         // sure we get the right message.
-        let result = tokio::time::timeout(Duration::from_secs(5), async {
-            loop {
-                match supervisor_supervision_receiver.recv().await {
-                    Ok(ProcSupervisionMessage::Update(state, _port)) => {
-                        match state.failed_actors.get(test_actor_ref.clone().actor_id()) {
-                            Some(actor_status) => return Ok(actor_status.clone()),
-                            None => {}
+        let result =
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    match supervisor_supervision_receiver.recv().await {
+                        Ok(ProcSupervisionMessage::Update(state, _port)) => {
+                            match state.failed_actors.iter().find(|(failed_id, _)| {
+                                failed_id == test_actor_ref.clone().actor_id()
+                            }) {
+                                Some((_, actor_status)) => return Ok(actor_status.clone()),
+                                None => {}
+                            }
                         }
+                        _ => anyhow::bail!("unexpected message type"),
                     }
-                    _ => anyhow::bail!("unexpected message type"),
                 }
-            }
-        })
-        .await;
+            })
+            .await;
         assert_matches!(
             result.unwrap().unwrap(),
             ActorStatus::Failed(msg) if msg.contains("test actor is erroring out")

--- a/hyperactor_multiprocess/src/supervision.rs
+++ b/hyperactor_multiprocess/src/supervision.rs
@@ -117,7 +117,7 @@ pub struct ProcSupervisionState {
     /// The proc health.
     pub proc_health: ProcStatus,
     /// Contains the supervision state of (failed) actors in the proc.
-    pub failed_actors: HashMap<ActorId, hyperactor::actor::ActorStatus>,
+    pub failed_actors: Vec<(ActorId, hyperactor::actor::ActorStatus)>,
 }
 
 impl ProcSupervisionState {

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -1255,7 +1255,7 @@ impl SystemMessageHandler for SystemActor {
                     proc_id: proc_id.clone(),
                     proc_addr: channel_addr.clone(),
                     proc_health: ProcStatus::Alive,
-                    failed_actors: HashMap::new(),
+                    failed_actors: Vec::new(),
                 },
                 lifecycle_mode.clone(),
                 this.clock(),
@@ -1931,7 +1931,7 @@ mod tests {
                 proc_addr: ChannelAddr::any(ChannelTransport::Local),
                 proc_id: proc_id_0.clone(),
                 proc_health: ProcStatus::Alive,
-                failed_actors: HashMap::new(),
+                failed_actors: Vec::new(),
             },
             ProcLifecycleMode::ManagedBySystem,
             &clock,
@@ -1944,7 +1944,7 @@ mod tests {
                 proc_addr: ChannelAddr::any(ChannelTransport::Local),
                 proc_id: proc_id_1.clone(),
                 proc_health: ProcStatus::Alive,
-                failed_actors: HashMap::new(),
+                failed_actors: Vec::new(),
             },
             ProcLifecycleMode::ManagedBySystem,
             &clock,
@@ -1968,7 +1968,7 @@ mod tests {
                 proc_addr: ChannelAddr::any(ChannelTransport::Local),
                 proc_id: proc_id_1.clone(),
                 proc_health: ProcStatus::Alive,
-                failed_actors: HashMap::new(),
+                failed_actors: Vec::new(),
             },
             &clock,
         );
@@ -2117,7 +2117,7 @@ mod tests {
                         proc_addr: local_proc_addr.clone(),
                         proc_id: local_proc_id.clone(),
                         proc_health: ProcStatus::Expired,
-                        failed_actors: HashMap::new(),
+                        failed_actors: Vec::new(),
                     }
                 )])
             })

--- a/monarch_worker/src/lib.rs
+++ b/monarch_worker/src/lib.rs
@@ -62,7 +62,6 @@ use hyperactor::cap;
 use hyperactor::forward;
 use hyperactor::message::IndexedErasedUnbound;
 use hyperactor::reference::ActorId;
-use hyperactor::supervision::ActorSupervisionEvent;
 use itertools::Itertools;
 use monarch_messages::controller::ControllerActor;
 use monarch_messages::controller::ControllerMessageClient;
@@ -239,15 +238,7 @@ impl Actor for WorkerActor {
         })
     }
 
-    async fn handle_supervision_event(
-        &mut self,
-        _this: &Instance<Self>,
-        _event: &ActorSupervisionEvent,
-    ) -> Result<bool, anyhow::Error> {
-        // Exit the worker directly on any worker actor errors, with error exit code.
-        tracing::info!("worker error happened, stop the worker process, exit code: 1");
-        std::process::exit(1);
-    }
+    // TODO: Exit the worker directly on any worker actor errors, with error exit code.
 }
 
 #[async_trait]

--- a/python/tests/test_controller.py
+++ b/python/tests/test_controller.py
@@ -636,12 +636,11 @@ class TestController:
 
 
 def test_panicking_worker():
-    with pytest.raises(DeviceException, match="Actor .* crashed") as exc_info:
-        with local_rust_device_mesh(2, 2) as _:
+    with pytest.raises(DeviceException, match="__test_panic called"):
+        with local_rust_device_mesh(1, 1) as _:
             panic()
             # induce a sync to allow the panic to propagate back
             _ = fetch_shard(torch.ones(2, 3)).result()
-    assert len(exc_info.value.frames) > 0
 
 
 def test_timeout_warning(caplog):


### PR DESCRIPTION
Summary:
We found that calling __test_panic on StreamActor does not propagate the rust stack trace back to the client. We expect to see a stack trace of the panic like
```
buck-out/v2/gen/fbcode/8afb8725dd81c3e5/monarch/python/tests/__test_controller__/test_controller#link-tree/monarch/python/tests/test_controller.py Actor mesh_0_worker[0].worker[1] crashed on unix!hdgSUkuhmycaIwwua4m2I7sI, check the host log for details
Traceback of the failure on worker (most recent call last):
  File "<unknown>", line None, in serving mesh_0_worker[0].worker[1]: panic: __test_panic called
  File "<unknown>", line None, in panicked at fbcode/monarch/monarch_messages/src/worker.rs:332:21
  File "<unknown>", line None, in    0: <unknown>
  File "<unknown>", line None, in    1: std::panicking::rust_panic_with_hook
  File "<unknown>", line None, in    2: <unknown>
  File "<unknown>", line None, in    3: std::sys::backtrace::__rust_end_short_backtrace::<std::panicking::begin_panic_handler::{closure#0}, !>
  File "<unknown>", line None, in    4: rust_begin_unwind
  File "<unknown>", line None, in    5: core::panicking::panic_fmt
  File "<unknown>", line None, in    6: <monarch_messages::worker::ResolvableFunction>::panic_if_requested
  File "<unknown>", line None, in    7: <unknown>
  File "<unknown>", line None, in    8: <unknown>
  File "<unknown>", line None, in    9: <monarch_worker::stream::StreamActor as hyperactor::actor::Handler<monarch_worker::stream::StreamMessage>>::handle::{closure#0}
  File "<unknown>", line None, in   10: <unknown>
  File "<unknown>", line None, in   11: <core::panic::unwind_safe::AssertUnwindSafe<<hyperactor::proc::Instance<monarch_worker::stream::StreamActor>>::run::{closure#0}> as core::future::future::Future>::poll
  File "<unknown>", line None, in   12: <tracing::instrument::Instrumented<<hyperactor::proc::Instance<monarch_worker::stream::StreamActor>>::serve::{closure#0}::{closure#0}> as core::future::future::Future>::poll
  File "<unknown>", line None, in   13: <unknown>
  File "<unknown>", line None, in   14: <tokio::runtime::task::trace::Root<hyperactor::panic_handler::with_backtrace_tracking<<hyperactor::proc::Instance<monarch_worker::stream::StreamActor>>::serve::{closure#0}>::{closure#0}> as core::future::future::Future>::poll
  File "<unknown>", line None, in   15: <pyo3::marker::Python>::allow_threads::<(), <monarch_worker::stream::StreamActor as hyperactor::actor::Actor>::spawn_server_task<hyperactor::panic_handler::with_backtrace_tracking<<hyperactor::proc::Instance<monarch_worker::stream::StreamActor>>::serve::{closure#0}>::{closure#0}>::{closure#0}::{closure#0}::{closure#0}::{closure#0}::{closure#0}>
  File "<unknown>", line None, in   16: tokio::runtime::context::runtime_mt::exit_runtime::<<monarch_worker::stream::StreamActor as hyperactor::actor::Actor>::spawn_server_task<hyperactor::panic_handler::with_backtrace_tracking<<hyperactor::proc::Instance<monarch_worker::stream::StreamActor>>::serve::{closure#0}>::{closure#0}>::{closure#0}::{closure#0}::{closure#0}, ()>
  File "<unknown>", line None, in   17: tokio::runtime::scheduler::multi_thread::worker::block_in_place::<<monarch_worker::stream::StreamActor as hyperactor::actor::Actor>::spawn_server_task<hyperactor::panic_handler::with_backtrace_tracking<<hyperactor::proc::Instance<monarch_worker::stream::StreamActor>>::serve::{closure#0}>::{closure#0}>::{closure#0}::{closure#0}::{closure#0}, ()>
  File "<unknown>", line None, in   18: <tokio::runtime::task::trace::Root<<monarch_worker::stream::StreamActor as hyperactor::actor::Actor>::spawn_server_task<hyperactor::panic_handler::with_backtrace_tracking<<hyperactor::proc::Instance<monarch_worker::stream::StreamActor>>::serve::{closure#0}>::{closure#0}>::{closure#0}::{closure#0}> as core::future::future::Future>::poll
  File "<unknown>", line None, in   19: std::sys::backtrace::__rust_begin_short_backtrace::<<monarch_worker::stream::StreamActor as hyperactor::actor::Actor>::spawn_server_task<hyperactor::panic_handler::with_backtrace_tracking<<hyperactor::proc::Instance<monarch_worker::stream::StreamActor>>::serve::{closure#0}>::{closure#0}>::{closure#0}, ()>
  File "<unknown>", line None, in   20: <unknown>
  File "<unknown>", line None, in   21: <unknown>
  File "<unknown>", line None, in   22: start_thread
  File "<unknown>", line None, in              at /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/nptl/pthread_create.c:434:8
  File "<unknown>", line None, in   23: __clone3
  File "<unknown>", line None, in              at /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81:0
  File "<unknown>", line None, in 
RuntimeError: Actor mesh_0_worker[0].worker[1] crashed on unix!hdgSUkuhmycaIwwua4m2I7sI, check the host log for details
```
but instead see an unhelpful 
```
processing error: mesh_0_worker[1].worker[0]: recv mesh_0_worker[1].worker[0][1029]: channel closed
```
This was caused by WorkerActor handling supervision events by exiting the process, but even when it does not do this, errors from handling messages once child StreamActors are down will shadow supervision events from child StreamActors. If an Actor encounters an error, we may want to check if there are supervision events available in it's receiver as those may be the root cause of the error

Differential Revision: D75490478


