### PR TITLE
: add new module 'affine'

### DIFF
--- a/ndslice/src/affine.rs
+++ b/ndslice/src/affine.rs
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use crate::slice::Slice;
+use crate::slice::SliceError;
+
+mod sealed {
+    // Private trait — only types in this module can implement it
+    pub trait Sealed {}
+}
+
+/// A trait for affine maps from integer coordinates to linear memory
+/// offsets.
+///
+/// This abstraction captures multidimensional layouts that can be
+/// interpreted as an affine transformation: `f(x) = offset +
+/// dot(strides, x)`.
+///
+/// Implementors of this trait define how multidimensional indices map
+/// to linear locations in memory.
+pub trait AffineMap: sealed::Sealed {
+    /// The number of dimensions in the domain of the map.
+    fn rank(&self) -> usize;
+
+    /// The shape of the domain (number of elements per dimension).
+    fn sizes(&self) -> &[usize];
+
+    /// Maps a multidimensional coordinate to a linear memory offset.
+    fn offset_of(&self, coord: &[usize]) -> Result<usize, SliceError>;
+}
+
+/// A trait for affine maps that support inverse lookup from linear
+/// offsets back to multidimensional coordinates.
+///
+/// This captures the inverse of the layout transformation defined by
+/// [`AffineMap::offset_of`]. Not all affine maps are invertible, but
+/// common layouts (e.g., row-major slices) are.
+pub trait AffineMapInverse: sealed::Sealed {
+    /// Computes the multidimensional coordinate for a given linear
+    /// offset, or returns `None` if the offset is out of bounds.
+    fn coord_of(&self, offset: usize) -> Option<Vec<usize>>;
+}
+
+impl sealed::Sealed for Slice {}
+
+impl AffineMap for Slice {
+    fn rank(&self) -> usize {
+        self.sizes().len()
+    }
+
+    fn sizes(&self) -> &[usize] {
+        self.sizes()
+    }
+
+    fn offset_of(&self, coord: &[usize]) -> Result<usize, SliceError> {
+        if coord.len() != self.rank() {
+            return Err(SliceError::InvalidDims {
+                expected: self.rank(),
+                got: coord.len(),
+            });
+        }
+
+        // Dot product ∑ᵢ (strideᵢ × coordᵢ)
+        let linear_offset = self
+            .strides()
+            .iter()
+            .zip(coord)
+            .map(|(s, i)| s * i)
+            .sum::<usize>();
+
+        Ok(self.offset() + linear_offset)
+    }
+}
+
+impl AffineMapInverse for Slice {
+    fn coord_of(&self, value: usize) -> Option<Vec<usize>> {
+        let mut pos = value.checked_sub(self.offset())?;
+        let mut result = vec![0; self.rank()];
+
+        let mut dims: Vec<_> = self
+            .strides()
+            .iter()
+            .zip(self.sizes().iter().enumerate())
+            .collect();
+
+        dims.sort_by_key(|&(stride, _)| *stride);
+
+        // Invert: offset = base + ∑ᵢ (strideᵢ × coordᵢ)
+        // Solve for coordᵢ by peeling off largest strides first:
+        //   coordᵢ = ⌊pos / strideᵢ⌋
+        //   pos   -= coordᵢ × strideᵢ
+        // If any coordᵢ ≥ sizeᵢ or pos ≠ 0 at the end, the offset is
+        // invalid.
+        for &(stride, (i, &size)) in dims.iter().rev() {
+            let index = if size > 1 { pos / stride } else { 0 };
+            if index >= size {
+                return None;
+            }
+            result[i] = index;
+            pos -= index * stride;
+        }
+
+        (pos == 0).then_some(result)
+    }
+}

--- a/ndslice/src/lib.rs
+++ b/ndslice/src/lib.rs
@@ -26,6 +26,9 @@ pub use slice::Slice;
 pub use slice::SliceError;
 pub use slice::SliceIterator;
 
+/// Affine indexing abstractions for multidimensional slices.
+pub mod affine;
+
 /// Selection algebra for describing multidimensional mesh regions.
 pub mod selection;
 

--- a/ndslice/src/shape.rs
+++ b/ndslice/src/shape.rs
@@ -52,6 +52,9 @@ pub enum ShapeError {
 
     #[error(transparent)]
     SliceError(#[from] SliceError),
+
+    #[error("rank mismatch: expected {expected}, got {actual}")]
+    RankMismatch { expected: usize, actual: usize },
 }
 
 /// A shape is a [`Slice`] with labeled dimensions and a selection API.

--- a/ndslice/src/slice.rs
+++ b/ndslice/src/slice.rs
@@ -9,6 +9,9 @@
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::affine::AffineMap;
+use crate::affine::AffineMapInverse;
+
 /// The type of error for slice operations.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
@@ -169,49 +172,14 @@ impl Slice {
 
     /// Return the location of the provided coordinates.
     pub fn location(&self, coord: &[usize]) -> Result<usize, SliceError> {
-        if coord.len() != self.sizes.len() {
-            return Err(SliceError::InvalidDims {
-                expected: self.sizes.len(),
-                got: coord.len(),
-            });
-        }
-        Ok(self.offset
-            + coord
-                .iter()
-                .zip(&self.strides)
-                .map(|(pos, stride)| pos * stride)
-                .sum::<usize>())
+        self.offset_of(coord)
     }
 
     /// Return the coordinates of the provided value in the n-d space of this
     /// Slice.
     pub fn coordinates(&self, value: usize) -> Result<Vec<usize>, SliceError> {
-        let mut pos = value
-            .checked_sub(self.offset)
-            .ok_or(SliceError::ValueNotInSlice { value })?;
-        let mut result = vec![0; self.sizes.len()];
-        let mut sorted_info: Vec<_> = self
-            .strides
-            .iter()
-            .zip(self.sizes.iter().enumerate())
-            .collect();
-        sorted_info.sort_by_key(|&(stride, _)| *stride);
-        for &(stride, (i, &size)) in sorted_info.iter().rev() {
-            let (index, new_pos) = if size > 1 {
-                (pos / stride, pos % stride)
-            } else {
-                (0, pos)
-            };
-            if index >= size {
-                return Err(SliceError::ValueNotInSlice { value });
-            }
-            result[i] = index;
-            pos = new_pos;
-        }
-        if pos != 0 {
-            return Err(SliceError::ValueNotInSlice { value });
-        }
-        Ok(result)
+        self.coord_of(value)
+            .ok_or(SliceError::ValueNotInSlice { value })
     }
 
     /// Retrieve the underlying location of the provided slice index.


### PR DESCRIPTION
Summary:
introduce `AffineMap` and use in `Slice::location`
	•	defines a trait for affine indexing over integer coordinates
	•	implements for Slice with existing logic moved into `offset_of`
	•	updates location to delegate to the trait
	•	no behavior change; covered by existing tests

this isolates layout logic and sets the stage for `view()` and other shape-preserving transforms.

Differential Revision: D75746358


