### PR TITLE
Ignore pycache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ python/**/*.so
 python/**/*.json
 python/**/*.html
 python/**/*.pkl
+python/**/__pycache__
 python/monarch.egg-info/*
 *.egg
 build/*


### PR DESCRIPTION
Summary: This diff updates `.gitignore` to ignore `pycache` files, which are temporary and generated during tests.

Differential Revision: D75763675


