### PR TITLE
: selection: normal: implement SelectionSYM for NormalizedSelection with canonical set structure (#104)

### DIFF
--- a/ndslice/src/selection/mod.rs
+++ b/ndslice/src/selection/mod.rs
@@ -93,6 +93,9 @@ pub mod token_parser;
 /// Shape navigation guided by [`Selection`] expressions.
 pub mod routing;
 
+/// Normalization logic for `Selection`.
+pub mod normal;
+
 pub mod test_utils;
 
 use std::collections::BTreeSet;
@@ -236,7 +239,20 @@ impl fmt::Display for Selection {
 /// For example, a selection like `sel!(["A100"]*)` matches only
 /// indices at the current dimension whose associated label value is
 /// `"A100"`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+///
+/// `Ord` is derived to allow deterministic sorting and set membership,
+/// based on lexicographic ordering of label strings.
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    PartialOrd,
+    Ord
+)]
 pub enum LabelKey {
     /// A plain string label value.
     Value(String),

--- a/ndslice/src/selection/mod.rs
+++ b/ndslice/src/selection/mod.rs
@@ -108,6 +108,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::Slice;
+use crate::selection::normal::NormalizedSelection;
 use crate::shape;
 use crate::shape::ShapeError;
 use crate::slice::SliceError;
@@ -345,48 +346,28 @@ pub fn structurally_equal(a: &Selection, b: &Selection) -> bool {
     }
 }
 
-/// Normalizes a [`Selection`] into a canonical form for structural
-/// comparison and hashing.
+/// Normalizes a [`Selection`] toward a canonical form for structural
+/// comparison.
 ///
-/// Normalization rewrites the selection into a canonical form
-/// suitable for structural comparison and hashing. For example, it
-/// may flatten nested unions, sort branches, or eliminate redundant
-/// constructs while preserving the selection's semantics.
+/// This rewrites the selection to eliminate redundant subtrees and
+/// bring structurally similar selections into a common
+/// representation. The result is suitable for comparison, hashing,
+/// and deduplication (e.g., in [`RoutingFrameKey`]).
 ///
-/// This function is designed to preserve the meaning of a selection
-/// (i.e., what it selects), but not necessarily the exact shape or
-/// format of the syntax tree used to express it.
-///
-/// # Note
-/// The current implementation is a placeholder and returns the
-/// input selection unchanged.
-pub fn normalize(selection: &Selection) -> Selection {
-    // TODO: Implement
-    selection.clone()
+/// Normalization preserves semantics but may alter syntactic
+/// structure. It is designed to improve over time as additional
+/// rewrites (e.g., flattening, simplification) are introduced.
+pub fn normalize(sel: &Selection) -> NormalizedSelection {
+    sel.fold::<normal::NormalizedSelection>()
 }
 
-/// Wrapper around a normalized `Selection` that provides `Hash` and
-/// `Eq` implementations based on structural equality.
+/// Wraps a normalized selection and derives `Eq` and `Hash`, relying
+/// on the canonical structure of the normalized form.
 ///
-/// This allows selections to be used as keys in hash maps or sets
-/// without requiring intrusive trait implementations on `Selection`
-/// itself.
-#[derive(Debug, Clone)]
-pub struct NormalizedSelectionKey(Selection);
-
-impl PartialEq for NormalizedSelectionKey {
-    fn eq(&self, other: &Self) -> bool {
-        crate::selection::structurally_equal(&self.0, &other.0)
-    }
-}
-
-impl Eq for NormalizedSelectionKey {}
-
-impl std::hash::Hash for NormalizedSelectionKey {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.0.to_string().hash(state)
-    }
-}
+/// This ensures that logically equivalent selections (e.g., unions
+/// with reordered elements) compare equal and hash identically.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NormalizedSelectionKey(NormalizedSelection);
 
 impl NormalizedSelectionKey {
     /// Constructs a `NormalizedSelectionKey`, normalizing the input
@@ -396,12 +377,12 @@ impl NormalizedSelectionKey {
     }
 
     /// Access the normalized selection.
-    pub fn inner(&self) -> &Selection {
+    pub fn inner(&self) -> &NormalizedSelection {
         &self.0
     }
 
-    /// Consumes the key and returns the owned normalized `Selection`.
-    pub fn into_inner(self) -> Selection {
+    /// Consumes the key and returns the owned normalized selection.
+    pub fn into_inner(self) -> NormalizedSelection {
         self.0
     }
 }

--- a/ndslice/src/selection/normal.rs
+++ b/ndslice/src/selection/normal.rs
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::collections::BTreeSet;
+
+use crate::selection::LabelKey;
+use crate::shape;
+
+/// A normalized form of `Selection`, used during canonicalization.
+///
+/// This structure uses `BTreeSet` for `Union` and `Intersection` to
+/// enable flattening, deduplication, and deterministic ordering.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NormalizedSelection {
+    False,
+    True,
+    All(Box<NormalizedSelection>),
+    First(Box<NormalizedSelection>),
+    Range(shape::Range, Box<NormalizedSelection>),
+    Label(Vec<LabelKey>, Box<NormalizedSelection>),
+    Any(Box<NormalizedSelection>),
+    Union(BTreeSet<NormalizedSelection>),
+    Intersection(BTreeSet<NormalizedSelection>),
+}

--- a/ndslice/src/selection/normal.rs
+++ b/ndslice/src/selection/normal.rs
@@ -8,14 +8,17 @@
 
 use std::collections::BTreeSet;
 
+use crate::Selection;
 use crate::selection::LabelKey;
+use crate::selection::SelectionSYM;
+use crate::selection::dsl;
 use crate::shape;
 
 /// A normalized form of `Selection`, used during canonicalization.
 ///
 /// This structure uses `BTreeSet` for `Union` and `Intersection` to
 /// enable flattening, deduplication, and deterministic ordering.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NormalizedSelection {
     False,
     True,
@@ -26,4 +29,118 @@ pub enum NormalizedSelection {
     Any(Box<NormalizedSelection>),
     Union(BTreeSet<NormalizedSelection>),
     Intersection(BTreeSet<NormalizedSelection>),
+}
+
+impl SelectionSYM for NormalizedSelection {
+    fn true_() -> Self {
+        Self::True
+    }
+
+    fn false_() -> Self {
+        Self::False
+    }
+
+    fn all(inner: Self) -> Self {
+        Self::All(Box::new(inner))
+    }
+
+    fn first(inner: Self) -> Self {
+        Self::First(Box::new(inner))
+    }
+
+    fn range<R: Into<shape::Range>>(range: R, inner: Self) -> Self {
+        Self::Range(range.into(), Box::new(inner))
+    }
+
+    fn label<L: Into<LabelKey>>(labels: Vec<L>, inner: Self) -> Self {
+        Self::Label(
+            labels.into_iter().map(Into::into).collect(),
+            Box::new(inner),
+        )
+    }
+
+    fn any(inner: Self) -> Self {
+        Self::Any(Box::new(inner))
+    }
+
+    fn intersection(lhs: Self, rhs: Self) -> Self {
+        let mut set = BTreeSet::new();
+        set.insert(lhs);
+        set.insert(rhs);
+        Self::Intersection(set)
+    }
+
+    fn union(lhs: Self, rhs: Self) -> Self {
+        let mut set = BTreeSet::new();
+        set.insert(lhs);
+        set.insert(rhs);
+        Self::Union(set)
+    }
+}
+
+impl From<NormalizedSelection> for Selection {
+    /// Converts the normalized form back into a standard `Selection`.
+    ///
+    /// Logical semantics are preserved, but normalized shape (e.g.,
+    /// set-based unions and intersections) is reconstructed as
+    /// left-associated binary trees.
+    fn from(norm: NormalizedSelection) -> Self {
+        use NormalizedSelection::*;
+        use dsl::*;
+
+        match norm {
+            True => true_(),
+            False => false_(),
+            All(inner) => all((*inner).into()),
+            First(inner) => first((*inner).into()),
+            Any(inner) => any((*inner).into()),
+            Union(set) => set
+                .into_iter()
+                .map(Into::into)
+                .reduce(Selection::union)
+                .unwrap_or_else(false_),
+            Intersection(set) => set
+                .into_iter()
+                .map(Into::into)
+                .reduce(Selection::intersection)
+                .unwrap_or_else(true_),
+            Range(r, inner) => Selection::range(r, (*inner).into()),
+            Label(labels, inner) => Selection::label(labels, (*inner).into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assert_structurally_eq;
+    use crate::selection;
+    use crate::selection::parse::parse;
+
+    /// Verifies that:
+    /// - Duplicate subtrees are structurally deduplicated by
+    ///   normalization
+    /// - The normalized form reifies to the expected `Selection` in
+    ///   this case
+    #[test]
+    fn normalization_deduplicates_and_reifies() {
+        let sel = parse("(* & *) | (* & *)").unwrap();
+        let norm = sel.fold::<NormalizedSelection>();
+
+        // Expected: Union { Intersection { All(True) } }
+        use NormalizedSelection::*;
+        let mut inner = BTreeSet::new();
+        inner.insert(All(Box::new(True)));
+
+        let mut outer = BTreeSet::new();
+        outer.insert(Intersection(inner));
+
+        assert_eq!(norm, Union(outer));
+
+        use selection::dsl::*;
+        let reified = norm.into();
+        let expected = all(true_());
+
+        assert_structurally_eq!(&reified, &expected);
+    }
 }

--- a/ndslice/src/shape.rs
+++ b/ndslice/src/shape.rs
@@ -359,7 +359,21 @@ macro_rules! select {
 
 /// A range of indices, with a stride. Ranges are convertible from
 /// native Rust ranges.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// Deriving `Eq`, `Ord` and `Hash` is sound because all fields are
+/// `Ord` and comparison is purely structural over `(start, end,
+/// step)`.
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    Hash,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    PartialOrd,
+    Ord
+)]
 pub struct Range(pub usize, pub Option<usize>, pub usize);
 
 impl Range {


### PR DESCRIPTION
Summary:

- implement `SelectionSYM` for `NormalizedSelection`
  - build canonical `Union` and `Intersection` nodes using `BTreeSet`
  - support all standard selection forms (e.g., `all`, `first`, `range`, `label`, `any`)

Differential Revision: D75742874


