### PR TITLE
Handle sim address directionality in UpdateAddress (#77)

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -1094,10 +1094,8 @@ mod tests {
 
         // Construct a proc forwarder in terms of the system sender.
         let listen_addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_forwarder = BoxedMailboxSender::new(DialMailboxRouter::new_with_default(
-            listen_addr.clone(),
-            system_sender,
-        ));
+        let proc_forwarder =
+            BoxedMailboxSender::new(DialMailboxRouter::new_with_default(system_sender));
 
         // Bootstrap proc 'local[0]', join the system.
         let world_id = id!(local);
@@ -1319,10 +1317,8 @@ mod tests {
 
         // Construct a proc forwarder in terms of the system sender.
         let listen_addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_forwarder = BoxedMailboxSender::new(DialMailboxRouter::new_with_default(
-            listen_addr.clone(),
-            system_sender,
-        ));
+        let proc_forwarder =
+            BoxedMailboxSender::new(DialMailboxRouter::new_with_default(system_sender));
 
         // Bootstrap proc 'local[0]', join the system.
         let world_id = id!(local);

--- a/hyperactor/src/channel/mod.rs
+++ b/hyperactor/src/channel/mod.rs
@@ -516,25 +516,6 @@ impl<M: RemoteMessage> Rx<M> for ChannelRx<M> {
 /// dropped whenever the returned Tx is dropped.
 #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ChannelError`.
 pub fn dial<M: RemoteMessage>(addr: ChannelAddr) -> Result<ChannelTx<M>, ChannelError> {
-    dial_impl(addr, None)
-}
-
-/// Dial the provided address, providing the address of the dialer, returning
-/// the corresponding Tx, or error if the channel cannot be established.
-/// The underlying connection is dropped whenever the returned Tx is dropped.
-#[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ChannelError`.
-pub fn dial_from_address<M: RemoteMessage>(
-    addr: ChannelAddr,
-    dialer: ChannelAddr,
-) -> Result<ChannelTx<M>, ChannelError> {
-    dial_impl(addr, Some(dialer))
-}
-
-#[crate::instrument]
-fn dial_impl<M: RemoteMessage>(
-    addr: ChannelAddr,
-    _dialer: Option<ChannelAddr>,
-) -> Result<ChannelTx<M>, ChannelError> {
     tracing::debug!(name = "dial", "dialing channel {}", addr);
     let inner = match addr {
         ChannelAddr::Local(port) => ChannelTxKind::Local(local::dial(port)?),

--- a/hyperactor/src/channel/mod.rs
+++ b/hyperactor/src/channel/mod.rs
@@ -533,14 +533,14 @@ pub fn dial_from_address<M: RemoteMessage>(
 #[crate::instrument]
 fn dial_impl<M: RemoteMessage>(
     addr: ChannelAddr,
-    dialer: Option<ChannelAddr>,
+    _dialer: Option<ChannelAddr>,
 ) -> Result<ChannelTx<M>, ChannelError> {
     tracing::debug!(name = "dial", "dialing channel {}", addr);
     let inner = match addr {
         ChannelAddr::Local(port) => ChannelTxKind::Local(local::dial(port)?),
         ChannelAddr::Tcp(addr) => ChannelTxKind::Tcp(net::tcp::dial(addr)),
         ChannelAddr::MetaTls(host, port) => ChannelTxKind::MetaTls(net::meta::dial(host, port)),
-        ChannelAddr::Sim(sim_addr) => ChannelTxKind::Sim(sim::dial::<M>(sim_addr, dialer)?),
+        ChannelAddr::Sim(sim_addr) => ChannelTxKind::Sim(sim::dial::<M>(sim_addr)?),
         ChannelAddr::Unix(path) => ChannelTxKind::Unix(net::unix::dial(path)),
     };
     Ok(ChannelTx { inner })

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -50,6 +50,25 @@ lazy_static! {
 static SIM_LINK_BUF_SIZE: usize = 256;
 static CLIENT_ADDRESS: &str = "unix!@client";
 
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    Ord,
+    PartialOrd,
+    Hash
+)]
+/// A channel address along with the address of the proxy for the process
+pub struct AddressProxyPair {
+    /// The address.
+    pub address: ChannelAddr,
+    /// The address of the proxy for the process
+    pub proxy: ChannelAddr,
+}
+
 /// An address for a simulated channel.
 #[derive(
     Clone,
@@ -63,6 +82,7 @@ static CLIENT_ADDRESS: &str = "unix!@client";
     Hash
 )]
 pub struct SimAddr {
+    src: Option<Box<AddressProxyPair>>,
     /// The address.
     addr: Box<ChannelAddr>,
     /// The proxy address.
@@ -72,7 +92,25 @@ pub struct SimAddr {
 impl SimAddr {
     /// Creates a new SimAddr.
     #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SimNetError`.
+    /// Creates a new SimAddr without a source to be served
     pub fn new(addr: ChannelAddr, proxy: ChannelAddr) -> Result<Self, SimNetError> {
+        Self::new_impl(None, addr, proxy)
+    }
+
+    /// Creates a new directional SimAddr meant to convey a channel between two addresses.
+    pub fn new_with_src(
+        src: AddressProxyPair,
+        addr: ChannelAddr,
+        proxy: ChannelAddr,
+    ) -> Result<Self, SimNetError> {
+        Self::new_impl(Some(Box::new(src)), addr, proxy)
+    }
+
+    fn new_impl(
+        src: Option<Box<AddressProxyPair>>,
+        addr: ChannelAddr,
+        proxy: ChannelAddr,
+    ) -> Result<Self, SimNetError> {
         if let ChannelAddr::Sim(_) = &addr {
             return Err(SimNetError::InvalidArg(format!(
                 "addr cannot be a sim address, found {}",
@@ -86,6 +124,7 @@ impl SimAddr {
             )));
         }
         Ok(Self {
+            src,
             addr: Box::new(addr),
             proxy: Box::new(proxy),
         })
@@ -100,26 +139,42 @@ impl SimAddr {
     pub fn proxy(&self) -> &ChannelAddr {
         &self.proxy
     }
+
+    /// Returns the source address and proxy.
+    pub fn src(&self) -> &Option<Box<AddressProxyPair>> {
+        &self.src
+    }
 }
 
 impl fmt::Display for SimAddr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "sim!{},{}", self.addr, self.proxy)
+        match &self.src {
+            None => write!(f, "{},{}", self.addr, self.proxy),
+            Some(src) => write!(
+                f,
+                "{},{},{},{}",
+                src.address, src.proxy, self.addr, self.proxy
+            ),
+        }
     }
 }
 
 /// Message Event that can be passed around in the simnet.
 #[derive(Debug)]
 pub(crate) struct MessageDeliveryEvent {
-    src_addr: Option<SimAddr>,
-    dest_addr: SimAddr,
+    src_addr: Option<AddressProxyPair>,
+    dest_addr: AddressProxyPair,
     data: Serialized,
     duration_ms: u64,
 }
 
 impl MessageDeliveryEvent {
     /// Creates a new MessageDeliveryEvent.
-    pub fn new(src_addr: Option<SimAddr>, dest_addr: SimAddr, data: Serialized) -> Self {
+    pub fn new(
+        src_addr: Option<AddressProxyPair>,
+        dest_addr: AddressProxyPair,
+        data: Serialized,
+    ) -> Self {
         Self {
             src_addr,
             dest_addr,
@@ -152,16 +207,16 @@ impl Event for MessageDeliveryEvent {
             "Sending message from {} to {}",
             self.src_addr
                 .as_ref()
-                .map_or("unknown".to_string(), |addr| addr.addr().to_string()),
-            self.dest_addr.addr().clone()
+                .map_or("unknown".to_string(), |addr| addr.address.to_string()),
+            self.dest_addr.address.clone()
         )
     }
 
     async fn read_simnet_config(&mut self, topology: &Arc<Mutex<SimNetConfig>>) {
         if let Some(src_addr) = &self.src_addr {
             let edge = SimNetEdge {
-                src: *src_addr.addr.clone(),
-                dst: *self.dest_addr.addr.clone(),
+                src: src_addr.address.clone(),
+                dst: self.dest_addr.address.clone(),
             };
             self.duration_ms = topology
                 .lock()
@@ -204,6 +259,7 @@ pub async fn operational_message_receiver()
 /// Returns a simulated channel address that is bound to "any" channel address.
 pub(crate) fn any(proxy: ChannelAddr) -> ChannelAddr {
     ChannelAddr::Sim(SimAddr {
+        src: None,
         addr: Box::new(ChannelAddr::any(proxy.transport())),
         proxy: Box::new(proxy),
     })
@@ -212,23 +268,47 @@ pub(crate) fn any(proxy: ChannelAddr) -> ChannelAddr {
 /// Parse the sim channel address. It should have two non-sim channel addresses separated by a comma.
 #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ChannelError`.
 pub fn parse(addr_string: &str) -> Result<ChannelAddr, ChannelError> {
-    let re = Regex::new(r"^([^,]+),([^,]+)$").map_err(|err| {
+    let re = Regex::new(r"([^,]+),([^,]+)(,([^,]+),([^,]+))?$").map_err(|err| {
         ChannelError::InvalidAddress(format!("invalid sim address regex: {}", err))
     })?;
 
     let result = re.captures(addr_string);
     if let Some(caps) = result {
-        let addr_str = caps.get(1).map_or("", |m| m.as_str());
-        let proxy_str = caps.get(2).map_or("", |m| m.as_str());
+        let parts = caps
+            .iter()
+            .skip(1)
+            .map(|cap| cap.map_or("", |m| m.as_str()))
+            .filter(|m| !m.is_empty())
+            .collect::<Vec<_>>();
 
-        if addr_str.starts_with("sim!") || proxy_str.starts_with("sim!") {
+        if parts.iter().any(|part| part.starts_with("sim!")) {
             return Err(ChannelError::InvalidAddress(addr_string.to_string()));
         }
 
-        let addr = addr_str.parse::<ChannelAddr>()?;
-        let proxy = proxy_str.parse::<ChannelAddr>()?;
+        match parts.len() {
+            2 => {
+                let addr = parts[0].parse::<ChannelAddr>()?;
+                let proxy = parts[1].parse::<ChannelAddr>()?;
 
-        Ok(ChannelAddr::Sim(SimAddr::new(addr, proxy)?))
+                Ok(ChannelAddr::Sim(SimAddr::new(addr, proxy)?))
+            }
+            5 => {
+                let src_addr = parts[0].parse::<ChannelAddr>()?;
+                let src_proxy = parts[1].parse::<ChannelAddr>()?;
+                let addr = parts[3].parse::<ChannelAddr>()?;
+                let proxy = parts[4].parse::<ChannelAddr>()?;
+
+                Ok(ChannelAddr::Sim(SimAddr::new_with_src(
+                    AddressProxyPair {
+                        address: src_addr,
+                        proxy: src_proxy,
+                    },
+                    addr,
+                    proxy,
+                )?))
+            }
+            _ => Err(ChannelError::InvalidAddress(addr_string.to_string())),
+        }
     } else {
         Err(ChannelError::InvalidAddress(addr_string.to_string()))
     }
@@ -250,40 +330,34 @@ pub struct SimDispatcher {
 
 fn create_egress_sender(
     addr: ChannelAddr,
-    local_proxy: Option<ChannelAddr>,
 ) -> anyhow::Result<Arc<dyn Tx<MessageEnvelope> + Send + Sync>> {
-    let tx = if let Some(proxy) = local_proxy {
-        channel::dial_from_address(addr, proxy)
-    } else {
-        channel::dial(addr)
-    }?;
+    let tx = channel::dial(addr)?;
     Ok(Arc::new(tx))
 }
 
 /// Check if the address is outside of the simulation.
-pub async fn is_external_addr(addr: &SimAddr) -> bool {
+pub async fn is_external_addr(addr: &AddressProxyPair) -> bool {
     HANDLE
         .proxy_addr()
         .await
-        .is_none_or(|local_proxy| local_proxy != *addr.proxy())
+        .is_none_or(|local_proxy| local_proxy != addr.proxy)
 }
 
 #[async_trait]
-impl Dispatcher<SimAddr> for SimDispatcher {
+impl Dispatcher<AddressProxyPair> for SimDispatcher {
     async fn send(
         &self,
-        src_addr: Option<SimAddr>,
-        addr: SimAddr,
+        src_addr: Option<AddressProxyPair>,
+        addr: AddressProxyPair,
         data: Serialized,
     ) -> Result<(), SimNetError> {
         if is_external_addr(&addr).await {
-            let local_proxy = HANDLE.proxy_addr().await;
-            let dst_proxy = *addr.proxy.clone();
+            let dst_proxy = addr.proxy.clone();
             let sender = self
                 .sender_cache
                 .entry(dst_proxy.clone())
-                .or_insert_with(|| create_egress_sender(dst_proxy.clone(), local_proxy).unwrap());
-            let forward_message = ProxyMessage::new(src_addr, Some(addr), data);
+                .or_insert_with(|| create_egress_sender(dst_proxy.clone()).unwrap());
+            let forward_message = ProxyMessage::new(src_addr.clone(), Some(addr.clone()), data);
             let serialized_forward_message = match Serialized::serialize(&forward_message) {
                 Ok(data) => data,
                 Err(err) => return Err(SimNetError::InvalidArg(err.to_string())),
@@ -295,17 +369,20 @@ impl Dispatcher<SimAddr> for SimDispatcher {
                 MessageEnvelope::new_unknown(port_id_placeholder, serialized_forward_message);
             return sender
                 .try_post(message, oneshot::channel().0)
-                .map_err(|err| SimNetError::InvalidNode(dst_proxy.to_string(), err.into()));
+                .map_err(|err| SimNetError::InvalidNode(addr.address.to_string(), err.into()));
         }
 
         self.dispatchers
-            .get(&addr.addr)
+            .get(&addr.address)
             .ok_or_else(|| {
-                SimNetError::InvalidNode(addr.to_string(), anyhow::anyhow!("no dispatcher found"))
+                SimNetError::InvalidNode(
+                    addr.address.to_string(),
+                    anyhow::anyhow!("no dispatcher found"),
+                )
             })?
             .send(data)
             .await
-            .map_err(|err| SimNetError::InvalidNode(addr.to_string(), err.into()))
+            .map_err(|err| SimNetError::InvalidNode(addr.address.to_string(), err.into()))
     }
 }
 
@@ -320,8 +397,8 @@ impl Default for SimDispatcher {
 
 #[derive(Debug)]
 pub(crate) struct SimTx<M: RemoteMessage> {
-    src_addr: Option<SimAddr>,
-    dst_addr: SimAddr,
+    src_addr: Option<AddressProxyPair>,
+    dst_addr: AddressProxyPair,
     status: watch::Receiver<TxStatus>, // Default impl. Always reports `Active`.
     _phantom: PhantomData<M>,
 }
@@ -342,7 +419,7 @@ impl<M: RemoteMessage> Tx<M> for SimTx<M> {
             Err(err) => return Err(SendError(err.into(), message)),
         };
         match &self.src_addr {
-            Some(src_addr) if src_addr.addr().to_string() == CLIENT_ADDRESS => HANDLE
+            Some(src_addr) if src_addr.address.to_string() == CLIENT_ADDRESS => HANDLE
                 .send_scheduled_event(ScheduledEvent {
                     event: Box::new(MessageDeliveryEvent::new(
                         self.src_addr.clone(),
@@ -351,7 +428,7 @@ impl<M: RemoteMessage> Tx<M> for SimTx<M> {
                     )),
                     time: SimClock.millis_since_start(RealClock.now()),
                 })
-                .map_err(|err| SendError(ChannelError::from(err), message)),
+                .map_err(|err: SimNetError| SendError(ChannelError::from(err), message)),
             _ => HANDLE
                 .send_event(Box::new(MessageDeliveryEvent::new(
                     self.src_addr.clone(),
@@ -361,8 +438,9 @@ impl<M: RemoteMessage> Tx<M> for SimTx<M> {
                 .map_err(|err| SendError(ChannelError::from(err), message)),
         }
     }
+
     fn addr(&self) -> ChannelAddr {
-        *self.dst_addr.addr.clone()
+        self.dst_addr.address.clone()
     }
 
     fn status(&self) -> &watch::Receiver<TxStatus> {
@@ -373,24 +451,18 @@ impl<M: RemoteMessage> Tx<M> for SimTx<M> {
 /// Dial a peer and return a transmitter. The transmitter can retrieve from the
 /// network the link latency.
 #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ChannelError`.
-pub(crate) fn dial<M: RemoteMessage>(
-    addr: SimAddr,
-    dialer: Option<ChannelAddr>,
-) -> Result<SimTx<M>, ChannelError> {
+pub(crate) fn dial<M: RemoteMessage>(addr: SimAddr) -> Result<SimTx<M>, ChannelError> {
     // This watch channel always reports active. The sender is
     // dropped.
     let (_, status) = watch::channel(TxStatus::Active);
-    let dialer = match dialer {
-        Some(ChannelAddr::Sim(sim_dialer)) => Ok(Some(sim_dialer)),
-        Some(_) => Err(ChannelError::InvalidAddress(
-            "sim address must but be dialed from a sim address".into(),
-        )),
-        None => Ok(None),
-    }?;
+    let dialer = addr.src().clone().map(|src| *src);
 
     Ok(SimTx {
         src_addr: dialer,
-        dst_addr: addr,
+        dst_addr: AddressProxyPair {
+            address: *addr.addr,
+            proxy: *addr.proxy,
+        },
         status,
         _phantom: PhantomData,
     })
@@ -461,14 +533,18 @@ mod tests {
         // dst proxy is the same as local proxy.
         let proxy = ChannelAddr::any(ChannelTransport::Unix);
         for (src_addr, dst_addr) in zip(srcs_ok, dst_ok) {
-            let dst_addr =
-                SimAddr::new(dst_addr.parse::<ChannelAddr>().unwrap(), proxy.clone()).unwrap();
-            let src_addr = ChannelAddr::Sim(
-                SimAddr::new(src_addr.parse::<ChannelAddr>().unwrap(), proxy.clone()).unwrap(),
-            );
+            let dst_addr = SimAddr::new_with_src(
+                AddressProxyPair {
+                    address: src_addr.parse::<ChannelAddr>().unwrap(),
+                    proxy: proxy.clone(),
+                },
+                dst_addr.parse::<ChannelAddr>().unwrap(),
+                proxy.clone(),
+            )
+            .unwrap();
 
             let (_, mut rx) = sim::serve::<u64>(dst_addr.clone()).unwrap();
-            let tx = sim::dial::<u64>(dst_addr, Some(src_addr)).unwrap();
+            let tx = sim::dial::<u64>(dst_addr).unwrap();
             tx.try_post(123, oneshot::channel().0).unwrap();
             assert_eq!(rx.recv().await.unwrap(), 123);
         }
@@ -493,13 +569,14 @@ mod tests {
         );
         // The sim addr we want simnet to send message to, it should have the egress_addr
         // as the proxy address of dst.
-        let src_addr = SimAddr::new(
-            "unix!@src".parse::<ChannelAddr>().unwrap(),
-            "unix!@proxy".parse::<ChannelAddr>().unwrap(),
-        )
-        .unwrap();
-        let egress_addr =
-            SimAddr::new("unix!@dst".parse::<ChannelAddr>().unwrap(), egress_addr).unwrap();
+        let src_addr = AddressProxyPair {
+            address: "unix!@src".parse::<ChannelAddr>().unwrap(),
+            proxy: "unix!@proxy".parse::<ChannelAddr>().unwrap(),
+        };
+        let egress_addr = AddressProxyPair {
+            address: "unix!@dst".parse::<ChannelAddr>().unwrap(),
+            proxy: egress_addr,
+        };
         let serialized_msg = Serialized::serialize(&msg).unwrap();
         dispatcher
             .send(
@@ -560,6 +637,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_parse_sim_addr() {
+        let sim_addr = "sim!unix!@dst,unix!@proxy";
+        let result = sim_addr.parse();
+        assert!(result.is_ok());
+        let ChannelAddr::Sim(sim_addr) = result.unwrap() else {
+            panic!("Expected a sim address");
+        };
+        assert!(sim_addr.src().is_none());
+        assert_eq!(sim_addr.addr().to_string(), "unix!@dst");
+        assert_eq!(sim_addr.proxy().to_string(), "unix!@proxy");
+
+        let sim_addr = "sim!unix!@src,unix!@proxy,unix!@dst,unix!@proxy";
+        let result = sim_addr.parse();
+        assert!(result.is_ok());
+        let ChannelAddr::Sim(sim_addr) = result.unwrap() else {
+            panic!("Expected a sim address");
+        };
+        assert!(sim_addr.src().is_some());
+        let src_pair = sim_addr.src().clone().unwrap();
+        assert_eq!(src_pair.address.to_string(), "unix!@src");
+        assert_eq!(src_pair.proxy.to_string(), "unix!@proxy");
+        assert_eq!(sim_addr.addr().to_string(), "unix!@dst");
+        assert_eq!(sim_addr.proxy().to_string(), "unix!@proxy");
+    }
+
+    #[tokio::test]
     async fn test_realtime_frontier() {
         tokio::time::pause();
         let sim_addr = SimAddr::new(
@@ -567,15 +670,17 @@ mod tests {
             "unix!@proxy".parse::<ChannelAddr>().unwrap(),
         )
         .unwrap();
-        let dialer_addr = ChannelAddr::Sim(
-            SimAddr::new(
-                "unix!@src".parse::<ChannelAddr>().unwrap(),
-                "unix!@proxy".parse::<ChannelAddr>().unwrap(),
-            )
-            .unwrap(),
-        );
+        let sim_addr_with_src = SimAddr::new_with_src(
+            AddressProxyPair {
+                address: "unix!@src".parse::<ChannelAddr>().unwrap(),
+                proxy: "unix!@proxy".parse::<ChannelAddr>().unwrap(),
+            },
+            "unix!@dst".parse::<ChannelAddr>().unwrap(),
+            "unix!@proxy".parse::<ChannelAddr>().unwrap(),
+        )
+        .unwrap();
         let (_, mut rx) = sim::serve::<()>(sim_addr.clone()).unwrap();
-        let tx = sim::dial::<()>(sim_addr, Some(dialer_addr)).unwrap();
+        let tx = sim::dial::<()>(sim_addr_with_src).unwrap();
         let simnet_config_yaml = r#"
         edges:
         - src: unix!@src
@@ -608,28 +713,27 @@ mod tests {
     #[tokio::test]
     async fn test_client_message_scheduled_realtime() {
         tokio::time::pause();
-        let dst_addr = SimAddr::new(
+        let controller_to_dst = SimAddr::new_with_src(
+            AddressProxyPair {
+                address: "unix!@controller".parse::<ChannelAddr>().unwrap(),
+                proxy: "unix!@proxy".parse::<ChannelAddr>().unwrap(),
+            },
             "unix!@dst".parse::<ChannelAddr>().unwrap(),
             "unix!@proxy".parse::<ChannelAddr>().unwrap(),
         )
         .unwrap();
-        let controller_addr = ChannelAddr::Sim(
-            SimAddr::new(
-                "unix!@controller".parse::<ChannelAddr>().unwrap(),
-                "unix!@proxy".parse::<ChannelAddr>().unwrap(),
-            )
-            .unwrap(),
-        );
-        let controller_tx = sim::dial::<()>(dst_addr.clone(), Some(controller_addr)).unwrap();
+        let controller_tx = sim::dial::<()>(controller_to_dst.clone()).unwrap();
 
-        let client_addr = ChannelAddr::Sim(
-            SimAddr::new(
-                "unix!@client".parse::<ChannelAddr>().unwrap(),
-                "unix!@proxy".parse::<ChannelAddr>().unwrap(),
-            )
-            .unwrap(),
-        );
-        let client_tx = sim::dial::<()>(dst_addr, Some(client_addr)).unwrap();
+        let client_to_dst = SimAddr::new_with_src(
+            AddressProxyPair {
+                address: "unix!@client".parse::<ChannelAddr>().unwrap(),
+                proxy: "unix!@proxy".parse::<ChannelAddr>().unwrap(),
+            },
+            "unix!@dst".parse::<ChannelAddr>().unwrap(),
+            "unix!@proxy".parse::<ChannelAddr>().unwrap(),
+        )
+        .unwrap();
+        let client_tx = sim::dial::<()>(client_to_dst).unwrap();
 
         // 1 second of latency
         let simnet_config_yaml = r#"

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -240,7 +240,7 @@ impl RemoteProcessAllocator {
                     return;
                 }
             };
-        let router = DialMailboxRouter::new(forwarder_addr.clone());
+        let router = DialMailboxRouter::new();
         let mailbox_handle = router
             .clone()
             .serve(forwarder_rx, monitored_return_handle());

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -146,11 +146,7 @@ impl MeshAgentMessageHandler for MeshAgent {
         // for better ergonomics in the allocator.
         self.supervisor = Some(supervisor);
         let client = MailboxClient::new(channel::dial(forwarder)?);
-        let self_address = address_book
-            .get(this.self_id().proc_id())
-            .cloned()
-            .ok_or_else(|| anyhow::anyhow!("self rank {} missing in address book", rank))?;
-        let router = DialMailboxRouter::new_with_default(self_address, client.into_boxed());
+        let router = DialMailboxRouter::new_with_default(client.into_boxed());
         for (proc_id, addr) in address_book {
             router.bind(proc_id.into(), addr);
         }

--- a/hyperactor_mesh/src/proc_mesh/mod.rs
+++ b/hyperactor_mesh/src/proc_mesh/mod.rs
@@ -155,10 +155,7 @@ impl ProcMesh {
         let (router_channel_addr, router_rx) = channel::serve(ChannelAddr::any(alloc.transport()))
             .await
             .map_err(|err| AllocatorError::Other(err.into()))?;
-        let router = DialMailboxRouter::new_with_default(
-            router_channel_addr.clone(),
-            global_router().boxed(),
-        );
+        let router = DialMailboxRouter::new_with_default(global_router().boxed());
         for (rank, (addr, _agent)) in running.iter().enumerate() {
             let proc_id = proc_ids.get(rank).unwrap().clone();
             router.bind(Reference::Proc(proc_id.clone()), addr.clone());

--- a/hyperactor_multiprocess/src/proc_actor.rs
+++ b/hyperactor_multiprocess/src/proc_actor.rs
@@ -378,9 +378,8 @@ impl ProcActor {
         labels: HashMap<String, String>,
         lifecycle_mode: ProcLifecycleMode,
     ) -> Result<BootstrappedProc, anyhow::Error> {
-        let system_sender = BoxedMailboxSender::new(MailboxClient::new(
-            channel::dial_from_address(bootstrap_addr.clone(), listen_addr.clone())?,
-        ));
+        let system_sender =
+            BoxedMailboxSender::new(MailboxClient::new(channel::dial(bootstrap_addr.clone())?));
         let clock = ClockKind::for_channel_addr(&listen_addr);
 
         let proc_forwarder =

--- a/hyperactor_multiprocess/src/proc_actor.rs
+++ b/hyperactor_multiprocess/src/proc_actor.rs
@@ -383,10 +383,8 @@ impl ProcActor {
         ));
         let clock = ClockKind::for_channel_addr(&listen_addr);
 
-        let proc_forwarder = BoxedMailboxSender::new(DialMailboxRouter::new_with_default(
-            listen_addr.clone(),
-            system_sender,
-        ));
+        let proc_forwarder =
+            BoxedMailboxSender::new(DialMailboxRouter::new_with_default(system_sender));
         let proc = Proc::new_with_clock(proc_id.clone(), proc_forwarder, clock);
         Self::bootstrap_for_proc(
             proc,
@@ -1371,10 +1369,8 @@ mod tests {
 
         // Construct a proc forwarder in terms of the system sender.
         let listen_addr = ChannelAddr::any(ChannelTransport::Tcp);
-        let proc_forwarder = BoxedMailboxSender::new(DialMailboxRouter::new_with_default(
-            listen_addr.clone(),
-            system_sender,
-        ));
+        let proc_forwarder =
+            BoxedMailboxSender::new(DialMailboxRouter::new_with_default(system_sender));
 
         // Bootstrap proc 'world[0]', join the system.
         let world_id = id!(world);
@@ -1497,10 +1493,8 @@ mod tests {
 
         // Construct a proc forwarder in terms of the system sender.
         let listen_addr = ChannelAddr::any(ChannelTransport::Tcp);
-        let proc_forwarder = BoxedMailboxSender::new(DialMailboxRouter::new_with_default(
-            listen_addr.clone(),
-            system_sender,
-        ));
+        let proc_forwarder =
+            BoxedMailboxSender::new(DialMailboxRouter::new_with_default(system_sender));
 
         // Bootstrap proc 'world[0]', join the system.
         let world_id = id!(world);

--- a/hyperactor_multiprocess/src/system.rs
+++ b/hyperactor_multiprocess/src/system.rs
@@ -52,11 +52,7 @@ impl System {
         world_eviction_timeout: tokio::time::Duration,
     ) -> Result<ServerHandle, anyhow::Error> {
         let clock = ClockKind::for_channel_addr(&addr);
-        let params = SystemActorParams::new(
-            addr.clone(),
-            supervision_update_timeout,
-            world_eviction_timeout,
-        );
+        let params = SystemActorParams::new(supervision_update_timeout, world_eviction_timeout);
         let (actor_handle, system_proc) = SystemActor::bootstrap_with_clock(params, clock).await?;
         actor_handle.bind::<SystemActor>();
 

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -186,7 +186,7 @@ impl PyProc {
         } else {
             ChannelAddr::any(bootstrap_addr.transport())
         };
-        let chan = channel::dial_from_address(bootstrap_addr.clone(), listen_addr.clone())?;
+        let chan = channel::dial(bootstrap_addr.clone())?;
         let system_sender = BoxedMailboxSender::new(MailboxClient::new(chan));
         let proc_forwarder =
             BoxedMailboxSender::new(DialMailboxRouter::new_with_default(system_sender));

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -188,10 +188,8 @@ impl PyProc {
         };
         let chan = channel::dial_from_address(bootstrap_addr.clone(), listen_addr.clone())?;
         let system_sender = BoxedMailboxSender::new(MailboxClient::new(chan));
-        let proc_forwarder = BoxedMailboxSender::new(DialMailboxRouter::new_with_default(
-            listen_addr.clone(),
-            system_sender,
-        ));
+        let proc_forwarder =
+            BoxedMailboxSender::new(DialMailboxRouter::new_with_default(system_sender));
         let proc = Proc::new_with_clock(
             proc_id.clone(),
             proc_forwarder,

--- a/monarch_simulator/src/bootstrap.rs
+++ b/monarch_simulator/src/bootstrap.rs
@@ -18,7 +18,9 @@ use hyperactor::ActorRef;
 use hyperactor::ProcId;
 use hyperactor::WorldId;
 use hyperactor::channel::ChannelAddr;
+use hyperactor::channel::sim::AddressProxyPair;
 use hyperactor::channel::sim::HANDLE;
+use hyperactor::channel::sim::SimAddr;
 use hyperactor::channel::sim::operational_message_receiver;
 use hyperactor::simnet::OperationalMessage;
 use hyperactor::simnet::SpawnMesh;
@@ -64,6 +66,20 @@ pub async fn spawn_controller(
     world_size: usize,
 ) -> anyhow::Result<ActorHandle<ProcActor>> {
     let listen_addr = ChannelAddr::any(bootstrap_addr.transport());
+    let ChannelAddr::Sim(bootstrap_addr) = bootstrap_addr else {
+        panic!("bootstrap_addr must be a SimAddr");
+    };
+    let bootstrap_addr = ChannelAddr::Sim(
+        SimAddr::new_with_src(
+            AddressProxyPair {
+                address: listen_addr.clone(),
+                proxy: bootstrap_addr.proxy().clone(),
+            },
+            bootstrap_addr.addr().clone(),
+            bootstrap_addr.proxy().clone(),
+        )
+        .unwrap(),
+    );
     tracing::info!(
         "controller listen addr: {}, bootstrap addr: {}",
         &listen_addr,
@@ -109,6 +125,20 @@ pub async fn spawn_sim_worker(
     let worker_proc_id = ProcId(worker_world_id.clone(), rank);
     let worker_actor_id = ActorId(worker_proc_id.clone(), "worker".into(), 0);
 
+    let ChannelAddr::Sim(bootstrap_addr) = bootstrap_addr else {
+        panic!("bootstrap_addr must be a SimAddr");
+    };
+    let bootstrap_addr = ChannelAddr::Sim(
+        SimAddr::new_with_src(
+            AddressProxyPair {
+                address: listen_addr.clone(),
+                proxy: bootstrap_addr.proxy().clone(),
+            },
+            bootstrap_addr.addr().clone(),
+            bootstrap_addr.proxy().clone(),
+        )
+        .unwrap(),
+    );
     tracing::info!(
         "worker {} listen addr: {}, bootstrap addr: {}",
         &worker_actor_id,

--- a/python/monarch/sim_mesh.py
+++ b/python/monarch/sim_mesh.py
@@ -82,7 +82,7 @@ def sim_mesh(
     client_proc_id = "client[0]"
     client_proc: Proc = init_proc(
         proc_id=client_proc_id,
-        bootstrap_addr=bootstrap.bootstrap_addr,
+        bootstrap_addr=bootstrap.client_bootstrap_addr,
         timeout=SIM_MESH_CLIENT_TIMEOUT,  # unused
         supervision_update_interval=SIM_MESH_CLIENT_SUPERVISION_UPDATE_INTERVAL,
         listen_addr=bootstrap.client_listen_addr,
@@ -202,6 +202,9 @@ class Bootstrap:
         proxy_addr = proxy_addr or f"unix!@{_random_id()}-proxy"
         self.bootstrap_addr: str = f"sim!unix!@system,{proxy_addr}"
         self.client_listen_addr: str = f"sim!unix!@client,{proxy_addr}"
+        self.client_bootstrap_addr: str = (
+            f"sim!unix!@client,{proxy_addr},unix!@system,{proxy_addr}"
+        )
         bootstrap_simulator_backend(self.bootstrap_addr, world_size)
 
         self._simulator_client = SimulatorClient(proxy_addr)
@@ -339,7 +342,7 @@ def sim_mesh_provider(
     client_proc_id = "client[0]"
     client_proc: Proc = init_proc(
         proc_id=client_proc_id,
-        bootstrap_addr=bootstrap.bootstrap_addr,
+        bootstrap_addr=bootstrap.client_bootstrap_addr,
         timeout=SIM_MESH_CLIENT_TIMEOUT,  # unused
         supervision_update_interval=SIM_MESH_CLIENT_SUPERVISION_UPDATE_INTERVAL,
         listen_addr=bootstrap.client_listen_addr,


### PR DESCRIPTION
Summary:

This is to address a quirk with SimAddresses which have a concept of directionality.

Suppose ControllerActor joins the system and provides the address sim!unix!controller,unix!proxy

If another actor on address sim!unix!src,unix!proxy wants to send a message to ControllerActor, UpdateAddress will tell it that the new address to contact ControllerActor with is sim!unix!controller,unix!proxy but because messages are sent along the channel src => controller, the src should be added to the address making it sim!unix!src,unix!proxy,unix!controller,unix!proxy

Reviewed By: kaiyuan-li

Differential Revision: D75648125
