### PR TITLE
: remoteprocess: relax timeouts

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -512,7 +512,7 @@ mod tests {
                         && hops.is_empty());
             }
 
-            #[timed_test::async_timed_test(timeout_secs = 30)]
+            #[timed_test::async_timed_test(timeout_secs = 60)]
             async fn test_actor_mesh_cast() {
                 // Verify a full broadcast in the mesh. Send a message
                 // to every actor and check each actor receives it.

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -1458,7 +1458,7 @@ mod test_alloc {
 
     use super::*;
 
-    #[async_timed_test(timeout_secs = 15)]
+    #[async_timed_test(timeout_secs = 60)]
     async fn test_alloc_simple() {
         // Use temporary config for this test
         let _guard = hyperactor::config::global::set_temp_config(hyperactor::config::Config {
@@ -1578,7 +1578,7 @@ mod test_alloc {
         task2_allocator_handle.await.unwrap();
     }
 
-    #[async_timed_test(timeout_secs = 15)]
+    #[async_timed_test(timeout_secs = 60)]
     async fn test_alloc_host_failure() {
         // Use temporary config for this test
         let _guard = hyperactor::config::global::set_temp_config(hyperactor::config::Config {


### PR DESCRIPTION
Summary:
some tests have timeouts that cause failures with the default mode (`fbcode//mode/dev`).

before:
```lang=txt, counterexample
$ buck2 test fbcode//monarch/hyperactor_mesh:hyperactor_mesh-unittest -- alloc::remoteprocess::test_alloc::test_alloc_simple actor_mesh::tests::process::test_actor_mesh_cast alloc::remoteprocess::test_alloc::test_alloc_host_failure
3 TESTS FAILED
  ✗ monarch/hyperactor_mesh:hyperactor_mesh-unittest - alloc::remoteprocess::test_alloc::test_alloc_simple
  ✗ monarch/hyperactor_mesh:hyperactor_mesh-unittest - alloc::remoteprocess::test_alloc::test_alloc_host_failure
  ✗ monarch/hyperactor_mesh:hyperactor_mesh-unittest - actor_mesh::tests::process::test_actor_mesh_cast
```
after:
```lang=txt
$ buck2 test fbcode//monarch/hyperactor_mesh:hyperactor_mesh-unittest -- alloc::remoteprocess::test_alloc::test_alloc_simple actor_mesh::tests::process::test_actor_mesh_cast alloc::remoteprocess::test_alloc::test_alloc_host_failure
Tests finished: Pass 3. Fail 0. Fatal 0. Skip 0. Build failure 0
```

Differential Revision: D75803641


