### PR TITLE
Move scuba logging to a background thread

### DIFF
--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -25,7 +25,6 @@ tracing-appender = "0.2.3"
 tracing-core = { version = "0.1.33", features = ["valuable"] }
 tracing-glog = { version = "0.4.0", features = ["ansi", "tracing-log"] }
 tracing-subscriber = { version = "0.3.19", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
-valuable = { version = "0.1", features = ["derive"] }
 
 [features]
 default = []


### PR DESCRIPTION
Summary: I started seeing pauses of 15-20us in traces when writing log to scuba. This change makes the impact to the critical logging path < 5us

Differential Revision: D75695994


