### PR TITLE
autocargo: use proper SPDX identifier for 3-clause BSD

### DIFF
--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -5,7 +5,7 @@ name = "controller"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [[bin]]
 name = "controller_bin"

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Facebook <opensource+crates-hyperactor@fb.com>"]
 edition = "2021"
 description = "a high-performance, scalable actor framework for cluster computing"
 repository = "https://github.com/pytorch-labs/monarch/"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [[bin]]
 name = "hyperactor_example_derive"

--- a/hyperactor_extension/Cargo.toml
+++ b/hyperactor_extension/Cargo.toml
@@ -5,7 +5,7 @@ name = "hyperactor_extension"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [dependencies]
 async-trait = "0.1.86"

--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Facebook <opensource+crates-hyperactor-macros@fb.com>"]
 edition = "2021"
 description = "macros to support the Hyperactor actors and data exchange"
 repository = "https://github.com/pytorch-labs/monarch/"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [lib]
 test = false

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -5,7 +5,7 @@ name = "hyperactor_mesh"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [[bin]]
 name = "hyperactor_mesh_example_dining_philosophers"

--- a/hyperactor_mesh_macros/Cargo.toml
+++ b/hyperactor_mesh_macros/Cargo.toml
@@ -5,7 +5,7 @@ name = "hyperactor_mesh_macros"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [lib]
 test = false

--- a/hyperactor_multiprocess/Cargo.toml
+++ b/hyperactor_multiprocess/Cargo.toml
@@ -5,7 +5,7 @@ name = "hyperactor_multiprocess"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.95"

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -5,7 +5,7 @@ name = "hyperactor_telemetry"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.95"

--- a/hyperactor_telemetry/tester/Cargo.toml
+++ b/hyperactor_telemetry/tester/Cargo.toml
@@ -5,7 +5,7 @@ name = "tester"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [[bin]]
 name = "tester"

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -5,7 +5,7 @@ name = "monarch_extension"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [lib]
 name = "_rust_bindings"

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -5,7 +5,7 @@ name = "monarch_hyperactor"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.95"

--- a/monarch_messages/Cargo.toml
+++ b/monarch_messages/Cargo.toml
@@ -5,7 +5,7 @@ name = "monarch_messages"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.95"

--- a/monarch_meta_extension/Cargo.toml
+++ b/monarch_meta_extension/Cargo.toml
@@ -5,7 +5,7 @@ name = "monarch_meta_extension"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [lib]
 name = "_lib_meta"

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -5,7 +5,7 @@ name = "monarch_rdma"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.95"

--- a/monarch_rdma/examples/Cargo.toml
+++ b/monarch_rdma/examples/Cargo.toml
@@ -5,7 +5,7 @@ name = "parameter_server"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [lib]
 path = "parameter_server.rs"

--- a/monarch_simulator/Cargo.toml
+++ b/monarch_simulator/Cargo.toml
@@ -5,7 +5,7 @@ name = "monarch_simulator_lib"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [[bin]]
 name = "monarch_simulator"

--- a/monarch_types/Cargo.toml
+++ b/monarch_types/Cargo.toml
@@ -5,7 +5,7 @@ name = "monarch_types"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [dependencies]
 derive_more = { version = "1.0.0", features = ["full"] }

--- a/monarch_worker/Cargo.toml
+++ b/monarch_worker/Cargo.toml
@@ -5,7 +5,7 @@ name = "monarch_worker"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.95"

--- a/ndslice/Cargo.toml
+++ b/ndslice/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Facebook <opensource+crates-ndslice@fb.com>"]
 edition = "2021"
 description = "data structures to support n-d arrays of ranks"
 repository = "https://github.com/pytorch-labs/monarch/"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.95"

--- a/timed_test/Cargo.toml
+++ b/timed_test/Cargo.toml
@@ -5,7 +5,7 @@ name = "timed_test"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 
 [lib]
 test = false

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -5,7 +5,7 @@ name = "torch-sys"
 version = "0.0.0"
 authors = ["Meta"]
 edition = "2021"
-license = "BSD-3"
+license = "BSD-3-Clause"
 links = "torch"
 
 [dependencies]


### PR DESCRIPTION
Summary:
Crates.io only accepts SPDX identifiers.

https://opensource.org/license/bsd-3-clause

Reviewed By: shayne-fletcher

Differential Revision: D75812533


