### PR TITLE
Add import torch to top of monarch's python module

### DIFF
--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -9,6 +9,10 @@
 from importlib import import_module as _import_module
 from typing import TYPE_CHECKING
 
+# Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
+# our RPATHs won't correctly find them.
+import torch  # noqa: F401
+
 # submodules of monarch should not be imported in this
 # top-level file because it will cause them to get
 # loaded even if they are not actually being used.

--- a/python/monarch/_monarch/__init__.py
+++ b/python/monarch/_monarch/__init__.py
@@ -3,7 +3,3 @@
 #
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
-
-# Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
-# our RPATHs won't correctly find them.
-import torch  # isort:skip


### PR DESCRIPTION
Summary:
In MAST jobs I was seeing this error:
```
Traceback (most recent call last):
  File "/packages/monarch/mast_client_script/src/mast_client_script.py", line 19, in <module>
    from monarch.common.invocation import DeviceException, RemoteException
  File "/packages/monarch/lib/monarch/common/invocation.py", line 11, in <module>
    from monarch._rust_bindings.monarch_hyperactor.proc import (  # manual=//monarch/monarch_extension:monarch_extension
ImportError: libc10.so: cannot open shared object file: No such file or directory
```

If we can import torch successfully, it should be able to pick up all of the libraries it uses like
`libc10.so`

Differential Revision: D75797487


