### PR TITLE
Introduce non-advancing events

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -1647,7 +1647,7 @@ mod tests {
         assert_eq!(result.0, Seq::default());
         assert!(result.1.expect("result").is_err());
 
-        let records = sim::records().await;
+        let records = sim::records().await.unwrap();
         eprintln!("{}", serde_json::to_string_pretty(&records).unwrap());
     }
     #[tokio::test]

--- a/hyperactor/src/clock.rs
+++ b/hyperactor/src/clock.rs
@@ -17,9 +17,9 @@ use serde::Serialize;
 
 use crate::Mailbox;
 use crate::channel::ChannelAddr;
-use crate::channel::sim::HANDLE;
 use crate::id;
 use crate::simnet::SleepEvent;
+use crate::simnet::simnet_handle;
 
 struct SimTime {
     start: tokio::time::Instant,
@@ -121,7 +121,8 @@ impl Clock for SimClock {
         let mailbox = Mailbox::new_detached(id!(proc[0].proc).clone());
         let (tx, rx) = mailbox.open_once_port::<()>();
 
-        HANDLE
+        simnet_handle()
+            .unwrap()
             .send_event(SleepEvent::new(
                 tx.bind(),
                 mailbox,

--- a/hyperactor/src/mailbox/mod.rs
+++ b/hyperactor/src/mailbox/mod.rs
@@ -2249,6 +2249,7 @@ mod tests {
     use crate::proc::Proc;
     use crate::reference::ProcId;
     use crate::reference::WorldId;
+    use crate::simnet;
     use crate::test_utils::tracing::set_tracing_env_filter;
 
     #[test]
@@ -2442,6 +2443,12 @@ mod tests {
     #[tokio::test]
     async fn test_sim_client_server() {
         let proxy = ChannelAddr::any(channel::ChannelTransport::Unix);
+        simnet::start(
+            ChannelAddr::any(ChannelTransport::Unix),
+            proxy.clone(),
+            1000,
+        )
+        .unwrap();
         let dst_addr =
             SimAddr::new("local!1".parse::<ChannelAddr>().unwrap(), proxy.clone()).unwrap();
         let src_to_dst = ChannelAddr::Sim(

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -847,7 +847,7 @@ impl<A: Actor> Instance<A> {
         let self_id = self.self_id().clone();
         let clock = self.proc.state().clock.clone();
         tokio::spawn(async move {
-            clock.sleep(delay).await;
+            clock.non_advancing_sleep(delay).await;
             if let Err(e) = port.send(message) {
                 // TODO: this is a fire-n-forget thread. We need to
                 // handle errors in a better way.

--- a/hyperactor_multiprocess/src/ping_pong.rs
+++ b/hyperactor_multiprocess/src/ping_pong.rs
@@ -21,6 +21,7 @@ mod tests {
     use hyperactor::id;
     use hyperactor::reference::Index;
     use hyperactor::reference::WorldId;
+    use hyperactor::simnet;
     use hyperactor::simnet::NetworkConfig;
     use hyperactor::test_utils::pingpong::PingPongActor;
     use hyperactor::test_utils::pingpong::PingPongActorParams;
@@ -36,6 +37,13 @@ mod tests {
     async fn test_sim_ping_pong() {
         let system_addr = "local!1".parse::<ChannelAddr>().unwrap();
         let proxy_addr = ChannelAddr::any(ChannelTransport::Unix);
+
+        simnet::start(
+            ChannelAddr::any(ChannelTransport::Unix),
+            proxy_addr.clone(),
+            1000,
+        )
+        .unwrap();
 
         let system_sim_addr = SimAddr::new(system_addr.clone(), proxy_addr.clone()).unwrap();
         let server_handle = System::serve(
@@ -107,7 +115,7 @@ edges:
 
         assert!(done_rx.recv().await.unwrap());
 
-        let records = sim::records().await;
+        let records = sim::records().await.unwrap();
         eprintln!(
             "records: {}",
             serde_json::to_string_pretty(&records).unwrap()

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -1813,7 +1813,6 @@ mod tests {
     use hyperactor::channel;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::channel::Rx;
-    use hyperactor::channel::sim::HANDLE;
     use hyperactor::clock::Clock;
     use hyperactor::clock::RealClock;
     use hyperactor::data::Serialized;
@@ -1824,6 +1823,7 @@ mod tests {
     use hyperactor::mailbox::PortHandle;
     use hyperactor::mailbox::PortReceiver;
     use hyperactor::mailbox::monitored_return_handle;
+    use hyperactor::simnet;
     use hyperactor::test_utils::pingpong::PingPongActorParams;
 
     use super::*;
@@ -2801,7 +2801,12 @@ mod tests {
     #[tokio::test]
     async fn test_update_sim_address() {
         let proxy = ChannelAddr::any(ChannelTransport::Unix);
-        HANDLE.add_proxy(proxy.clone()).await.unwrap();
+        simnet::start(
+            ChannelAddr::any(ChannelTransport::Unix),
+            proxy.clone(),
+            1000,
+        )
+        .unwrap();
 
         let src_id = id!(proc[0].actor);
         let src_addr =

--- a/monarch_extension/src/simulator_client.rs
+++ b/monarch_extension/src/simulator_client.rs
@@ -51,9 +51,20 @@ fn wrap_operational_message(operational_message: OperationalMessage) -> MessageE
 }
 
 #[pyfunction]
-fn bootstrap_simulator_backend(py: Python, system_addr: String, world_size: i32) -> PyResult<()> {
+fn bootstrap_simulator_backend(
+    py: Python,
+    system_addr: String,
+    proxy_addr: String,
+    world_size: i32,
+) -> PyResult<()> {
     signal_safe_block_on(py, async move {
-        match bootstrap(system_addr.parse().unwrap(), world_size as usize).await {
+        match bootstrap(
+            system_addr.parse().unwrap(),
+            proxy_addr.parse().unwrap(),
+            world_size as usize,
+        )
+        .await
+        {
             Ok(_) => Ok(()),
             Err(err) => Err(PyRuntimeError::new_err(err.to_string())),
         }

--- a/monarch_simulator/src/main.rs
+++ b/monarch_simulator/src/main.rs
@@ -18,6 +18,8 @@ use monarch_simulator_lib::bootstrap::bootstrap;
 struct Args {
     #[arg(short, long)]
     system_addr: ChannelAddr,
+    #[arg(short, long)]
+    proxy_addr: ChannelAddr,
 }
 
 const TITLE: &str = r#"
@@ -39,9 +41,10 @@ async fn main() -> Result<ExitCode> {
     let args = Args::parse();
 
     let system_addr = args.system_addr.clone();
+    let proxy_addr = args.proxy_addr.clone();
     tracing::info!("starting Monarch simulation");
 
-    let operational_listener_handle = bootstrap(system_addr, 1).await?;
+    let operational_listener_handle = bootstrap(system_addr, proxy_addr, 1).await?;
 
     operational_listener_handle
         .await

--- a/monarch_simulator/src/simulator.rs
+++ b/monarch_simulator/src/simulator.rs
@@ -116,6 +116,8 @@ mod tests {
     use hyperactor::ProcId;
     use hyperactor::WorldId;
     use hyperactor::channel::ChannelAddr;
+    use hyperactor::channel::ChannelTransport;
+    use hyperactor::simnet;
     use rand::Rng;
     use rand::distributions::Alphanumeric;
 
@@ -131,8 +133,16 @@ mod tests {
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_spawn_and_kill_mesh() {
-        let s = random_str();
-        let system_addr = format!("sim!unix!@system,unix!@{}", &s)
+        let proxy = format!("unix!@{}", random_str());
+
+        simnet::start(
+            ChannelAddr::any(ChannelTransport::Unix),
+            proxy.parse().unwrap(),
+            1000,
+        )
+        .unwrap();
+
+        let system_addr = format!("sim!unix!@system,{}", &proxy)
             .parse::<ChannelAddr>()
             .unwrap();
         let mut simulator = super::Simulator::new(system_addr.clone()).await.unwrap();

--- a/monarch_simulator/src/worker.rs
+++ b/monarch_simulator/src/worker.rs
@@ -21,13 +21,13 @@ use hyperactor::ActorRef;
 use hyperactor::Instance;
 use hyperactor::Mailbox;
 use hyperactor::Named;
-use hyperactor::channel::sim::HANDLE;
 use hyperactor::data::Serialized;
 use hyperactor::forward;
 use hyperactor::id;
 use hyperactor::message::IndexedErasedUnbound;
 use hyperactor::reference::ActorId;
 use hyperactor::simnet::TorchOpEvent;
+use hyperactor::simnet::simnet_handle;
 use monarch_messages::controller::ControllerActor;
 use monarch_messages::controller::ControllerMessageClient;
 use monarch_messages::controller::Seq;
@@ -293,7 +293,7 @@ impl WorkerMessageHandler for WorkerActor {
         match &params.function.as_torch_op() {
             Some((op, _)) => {
                 self.call_torch_op(op, params.args, params.kwargs, this.self_id().clone())
-                    .await;
+                    .await?;
             }
             _ => {
                 let _ = self.call_python_fn(
@@ -679,7 +679,7 @@ impl WorkerActor {
         args: Vec<WireValue>,
         kwargs: HashMap<String, WireValue>,
         actor_id: ActorId,
-    ) {
+    ) -> Result<()> {
         let args_string = args
             .iter()
             .filter(|&wirevalue| wirevalue.is_ref())
@@ -700,7 +700,7 @@ impl WorkerActor {
         let mailbox = Mailbox::new_detached(id!(proc[0].proc).clone());
         let (tx, rx) = mailbox.open_once_port::<()>();
 
-        HANDLE
+        simnet_handle()?
             .send_event(TorchOpEvent::new(
                 op.to_string(),
                 tx.bind(),
@@ -712,6 +712,8 @@ impl WorkerActor {
             .unwrap();
 
         rx.recv().await.unwrap();
+
+        Ok(())
     }
 
     fn call_python_fn(
@@ -732,8 +734,11 @@ mod tests {
 
     use anyhow::Result;
     use futures::future::try_join_all;
+    use hyperactor::channel::ChannelAddr;
+    use hyperactor::channel::ChannelTransport;
     use hyperactor::id;
     use hyperactor::proc::Proc;
+    use hyperactor::simnet;
     use monarch_types::PyTree;
     use torch_sys::Layout;
     use torch_sys::RValue;
@@ -784,6 +789,12 @@ mod tests {
 
     #[tokio::test]
     async fn worker_reduce() -> Result<()> {
+        simnet::start(
+            "local!0".parse::<ChannelAddr>().unwrap(),
+            ChannelAddr::any(ChannelTransport::Unix),
+            1000,
+        )
+        .unwrap();
         let proc = Proc::local();
         //let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller")?;
         let client = proc.attach("client")?;

--- a/python/monarch/_rust_bindings/monarch_extension/simulator_client.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/simulator_client.pyi
@@ -52,7 +52,9 @@ class SimulatorClient:
         """
         ...
 
-def bootstrap_simulator_backend(system_addr: str, world_size: int) -> None:
+def bootstrap_simulator_backend(
+    system_addr: str, proxy_addr: str, world_size: int
+) -> None:
     """
     Bootstrap the simulator backend on the current process
     """

--- a/python/monarch/sim_mesh.py
+++ b/python/monarch/sim_mesh.py
@@ -205,7 +205,7 @@ class Bootstrap:
         self.client_bootstrap_addr: str = (
             f"sim!unix!@client,{proxy_addr},unix!@system,{proxy_addr}"
         )
-        bootstrap_simulator_backend(self.bootstrap_addr, world_size)
+        bootstrap_simulator_backend(self.bootstrap_addr, proxy_addr, world_size)
 
         self._simulator_client = SimulatorClient(proxy_addr)
         for i in range(num_meshes):


### PR DESCRIPTION
Summary:
TLDR;

We go from simulating 50 steps on a toy model D72348663 in
```
Simulated MNIST training completed in 341.3135597705841s
```
to
```
Simulated MNIST training completed in 7.598558664321899s
```
and can run fast enough to simulate llama3 and nanoGPT training in reasonable time

___________________________


Consider the following scenario with `self_message_with_delay`:

1. Event queue: [Sleep(10)], T = 0
2. Simnet dequeues Sleep(10) and advances to T=10
3. `self_message_with_delay` task wakes up and sends ControllerMessage::CheckSupervision
4. ControllerActor handles ControllerMessage::CheckSupervision and calls `self_message_with_delay(ControllerMessage::CheckSupervision)`
5. Event queue: [Sleep(10)], T = 20

This loops endlessly and we advance the time far further than we should.

Before we were remedying this in the Simnet event loop by adding a short debounce interval that would cause us to only move on to handling the events once the debounce duration has elapsed and no more events have arrived. In the above scenario this would mean that the events between T=10 and T=20 would arrive and be handled instead of instantly advancing to T=20, T=30, T=40...

The problem with this is this actually dramatically slows down the wall time of running the simulator such that examples like nanoGPT and llama3 would take very long to simulate a single step.

The solution to this is to have 2 separate queues:

queue 1: events that are allowed to advance the sim time on it's own
queue 2: events that are allowed to advance the sim time only when the earliest event in queue 1 comes after the earliest event in queue 2, or if some debounce period such that only queue 2 has events has elapsed. The second scenario occurs when there is a supervision failure

Doing this allows us to safely remove the debounce, dramatically speeding up the wall time it takes to run the simulator while also ensuring that events from `self_message_with_delay` are scheduled at the correct time

Differential Revision: D75900568


