### PR TITLE
mesh: generic ActorMesh trait

### DIFF
--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -19,9 +19,10 @@ use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::PortRef;
 use hyperactor::message::IndexedErasedUnbound;
-use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::Mesh;
 use hyperactor_mesh::ProcMesh;
+use hyperactor_mesh::RootActorMesh;
+use hyperactor_mesh::actor_mesh::ActorMesh;
 use hyperactor_mesh::actor_mesh::Cast;
 use hyperactor_mesh::alloc::AllocSpec;
 use hyperactor_mesh::alloc::Allocator;
@@ -166,17 +167,20 @@ impl Handler<Cast<PhilosopherMessage>> for PhilosopherActor {
     }
 }
 
-struct Waiter<'a> {
+struct Waiter<A> {
     /// A map from chopstick to the rank of the philosopher who holds it.
     chopstick_assignments: HashMap<usize, usize>,
     /// A map from chopstick to the rank of the philosopher who requested it.
     chopstick_requests: HashMap<usize, usize>,
     /// ActorMesh of the philosophers.
-    philosophers: ActorMesh<'a, PhilosopherActor>,
+    philosophers: A,
 }
 
-impl<'a> Waiter<'a> {
-    fn new(philosophers: ActorMesh<'a, PhilosopherActor>) -> Self {
+impl<A> Waiter<A>
+where
+    A: ActorMesh<Actor = PhilosopherActor>,
+{
+    fn new(philosophers: A) -> Self {
         Self {
             chopstick_assignments: Default::default(),
             chopstick_requests: Default::default(),

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -24,7 +24,7 @@ pub mod reference;
 pub mod shortuuid;
 pub mod test_utils;
 
-pub use actor_mesh::ActorMesh;
+pub use actor_mesh::RootActorMesh;
 pub use actor_mesh::SlicedActorMesh;
 pub use bootstrap::bootstrap;
 pub use bootstrap::bootstrap_or_die;

--- a/hyperactor_mesh/src/mesh.rs
+++ b/hyperactor_mesh/src/mesh.rs
@@ -14,7 +14,7 @@ use ndslice::SliceIterator;
 
 /// A mesh of nodes, organized into the topology described by its shape (see [`Shape`]).
 #[async_trait]
-pub trait Mesh: Sized {
+pub trait Mesh {
     /// The type of the node contained in the mesh.
     type Node;
 
@@ -46,7 +46,7 @@ pub trait Mesh: Sized {
 }
 
 /// An iterator over the nodes of a mesh.
-pub struct MeshIter<'a, M: Mesh> {
+pub struct MeshIter<'a, M: Mesh + ?Sized> {
     mesh: &'a M,
     slice_iter: SliceIterator<'a>,
 }

--- a/hyperactor_mesh/src/proc_mesh/mod.rs
+++ b/hyperactor_mesh/src/proc_mesh/mod.rs
@@ -39,7 +39,7 @@ use ndslice::ShapeError;
 
 use crate::CommActor;
 use crate::Mesh;
-use crate::actor_mesh::ActorMesh;
+use crate::actor_mesh::RootActorMesh;
 use crate::alloc::Alloc;
 use crate::alloc::AllocatorError;
 use crate::alloc::ProcState;
@@ -347,11 +347,11 @@ impl ProcMesh {
         &self,
         actor_name: &str,
         params: &A::Params,
-    ) -> Result<ActorMesh<'_, A>, anyhow::Error>
+    ) -> Result<RootActorMesh<'_, A>, anyhow::Error>
     where
         A::Params: RemoteMessage,
     {
-        Ok(ActorMesh::new(
+        Ok(RootActorMesh::new(
             self,
             actor_name.to_string(),
             Self::spawn_on_procs::<A>(&self.client, self.agents(), actor_name, params).await?,
@@ -440,7 +440,7 @@ pub trait SharedSpawnable {
         &self,
         actor_name: &str,
         params: &A::Params,
-    ) -> Result<ActorMesh<'static, A>, anyhow::Error>
+    ) -> Result<RootActorMesh<'static, A>, anyhow::Error>
     where
         A::Params: RemoteMessage;
 }
@@ -451,11 +451,11 @@ impl SharedSpawnable for Arc<ProcMesh> {
         &self,
         actor_name: &str,
         params: &A::Params,
-    ) -> Result<ActorMesh<'static, A>, anyhow::Error>
+    ) -> Result<RootActorMesh<'static, A>, anyhow::Error>
     where
         A::Params: RemoteMessage,
     {
-        Ok(ActorMesh::new_shared(
+        Ok(RootActorMesh::new_shared(
             Arc::clone(self),
             actor_name.to_string(),
             ProcMesh::spawn_on_procs::<A>(&self.client, self.agents(), actor_name, params).await?,
@@ -537,6 +537,7 @@ mod tests {
     use ndslice::shape;
 
     use super::*;
+    use crate::actor_mesh::ActorMesh;
     use crate::actor_mesh::test_util::Error;
     use crate::actor_mesh::test_util::TestActor;
     use crate::alloc::AllocSpec;

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -9,8 +9,9 @@
 use std::sync::Arc;
 
 use hyperactor::ActorRef;
-use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::Mesh;
+use hyperactor_mesh::RootActorMesh;
+use hyperactor_mesh::actor_mesh::ActorMesh;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 
@@ -25,7 +26,7 @@ use crate::shape::PyShape;
     module = "monarch._rust_bindings.monarch_hyperactor.actor_mesh"
 )]
 pub struct PythonActorMesh {
-    pub(super) inner: Arc<ActorMesh<'static, PythonActor>>,
+    pub(super) inner: Arc<RootActorMesh<'static, PythonActor>>,
     pub(super) client: PyMailbox,
 }
 

--- a/monarch_rdma/src/rdma_buffer.rs
+++ b/monarch_rdma/src/rdma_buffer.rs
@@ -400,9 +400,9 @@ impl RdmaBuffer {
 
 #[cfg(test)]
 mod tests {
-    use hyperactor_mesh::ActorMesh;
     use hyperactor_mesh::Mesh;
     use hyperactor_mesh::ProcMesh;
+    use hyperactor_mesh::RootActorMesh;
     use hyperactor_mesh::alloc::AllocConstraints;
     use hyperactor_mesh::alloc::AllocSpec;
     use hyperactor_mesh::alloc::Allocator;
@@ -490,7 +490,7 @@ mod tests {
             })
             .await?;
         let proc_mesh_1 = ProcMesh::allocate(alloc1).await?;
-        let actor_mesh_1: ActorMesh<'_, RdmaManagerActor> =
+        let actor_mesh_1: RootActorMesh<'_, RdmaManagerActor> =
             proc_mesh_1.spawn("rdma_manager_1", &config1).await.unwrap();
         let buffer2_data = create_test_data(BUFFER_SIZE);
         let alloc2 = LocalAllocator
@@ -500,7 +500,7 @@ mod tests {
             })
             .await?;
         let proc_mesh_2 = ProcMesh::allocate(alloc2).await?;
-        let actor_mesh_2: ActorMesh<'_, RdmaManagerActor> =
+        let actor_mesh_2: RootActorMesh<'_, RdmaManagerActor> =
             proc_mesh_2.spawn("rdma_manager_2", &config2).await.unwrap();
 
         let actor_ref = actor_mesh_1.get(0).unwrap();
@@ -566,7 +566,7 @@ mod tests {
             })
             .await?;
         let proc_mesh_1 = ProcMesh::allocate(alloc1).await?;
-        let actor_mesh_1: ActorMesh<'_, RdmaManagerActor> =
+        let actor_mesh_1: RootActorMesh<'_, RdmaManagerActor> =
             proc_mesh_1.spawn("rdma_manager_1", &config1).await.unwrap();
         let buffer2_data = vec![0u8; BUFFER_SIZE].into_boxed_slice();
         let alloc2 = LocalAllocator
@@ -576,7 +576,7 @@ mod tests {
             })
             .await?;
         let proc_mesh_2 = ProcMesh::allocate(alloc2).await?;
-        let actor_mesh_2: ActorMesh<'_, RdmaManagerActor> =
+        let actor_mesh_2: RootActorMesh<'_, RdmaManagerActor> =
             proc_mesh_2.spawn("rdma_manager_2", &config2).await.unwrap();
 
         let actor_ref = actor_mesh_1.get(0).unwrap();

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -517,9 +517,9 @@ mod tests {
     use hyperactor::Mailbox;
     use hyperactor::clock::Clock;
     use hyperactor::clock::RealClock;
-    use hyperactor_mesh::ActorMesh;
     use hyperactor_mesh::Mesh;
     use hyperactor_mesh::ProcMesh;
+    use hyperactor_mesh::RootActorMesh;
     use hyperactor_mesh::alloc::AllocConstraints;
     use hyperactor_mesh::alloc::AllocSpec;
     use hyperactor_mesh::alloc::Allocator;
@@ -591,7 +591,7 @@ mod tests {
                 .unwrap();
 
             let proc_mesh_1 = Box::leak(Box::new(ProcMesh::allocate(alloc_1).await.unwrap()));
-            let actor_mesh_1: ActorMesh<'_, RdmaManagerActor> =
+            let actor_mesh_1: RootActorMesh<'_, RdmaManagerActor> =
                 proc_mesh_1.spawn("rdma_manager", &config1).await.unwrap();
 
             let alloc_2 = LocalAllocator
@@ -603,7 +603,7 @@ mod tests {
                 .unwrap();
 
             let proc_mesh_2 = Box::leak(Box::new(ProcMesh::allocate(alloc_2).await.unwrap()));
-            let actor_mesh_2: ActorMesh<'_, RdmaManagerActor> =
+            let actor_mesh_2: RootActorMesh<'_, RdmaManagerActor> =
                 proc_mesh_2.spawn("rdma_manager", &config2).await.unwrap();
 
             let mut buffer1 = vec![0u8; buffer_size].into_boxed_slice();


### PR DESCRIPTION
Summary: This is to give actor meshes (whether a root mesh or a sliced one) a consistent interface. Cast thus works across both.

Reviewed By: zdevito

Differential Revision: D75904430


