### PR TITLE
Failure robustness with explicit failure ProcState

### DIFF
--- a/hyperactor_mesh/src/alloc/mod.rs
+++ b/hyperactor_mesh/src/alloc/mod.rs
@@ -112,6 +112,19 @@ pub enum ProcState {
         proc_id: ProcId,
         reason: ProcStopReason,
     },
+    /// Allocation process encountered an irrecoverable error. Depending on the
+    /// implementation, the allocation process may continue transiently and calls
+    /// to next() may return some events. But eventually the allocation will not
+    /// be complete. Callers can use the `description` to determine the reason for
+    /// the failure.
+    /// Allocation can then be cleaned up by calling `stop()`` on the `Alloc` and
+    /// drain the iterator for clean shutdown.
+    Failed {
+        /// The world ID of the failed alloc.
+        world_id: WorldId,
+        /// A description of the failure.
+        description: String,
+    },
 }
 
 impl fmt::Display for ProcState {
@@ -134,6 +147,12 @@ impl fmt::Display for ProcState {
             }
             ProcState::Stopped { proc_id, reason } => {
                 write!(f, "{}: stopped: {}", proc_id, reason)
+            }
+            ProcState::Failed {
+                description,
+                world_id,
+            } => {
+                write!(f, "{}: failed: {}", world_id, description)
             }
         }
     }

--- a/hyperactor_mesh/src/proc_mesh/mod.rs
+++ b/hyperactor_mesh/src/proc_mesh/mod.rs
@@ -142,6 +142,13 @@ impl ProcMesh {
                         tracing::info!("proc {} rank {}: stopped: {}", proc_id, rank, reason);
                     }
                 }
+                ProcState::Failed {
+                    world_id,
+                    description,
+                } => {
+                    tracing::error!("allocation failed for world {}: {}", world_id, description);
+                    return Err(AllocatorError::Other(anyhow::Error::msg(description)));
+                }
             }
         }
 


### PR DESCRIPTION
Summary:
Previously many permenant failures were simply handled by either indefinitly blocking the `Alloc` iterator, or prematurely return `None`.

This diff adds a new `ProcState::Failed` event to indicate to downstream that the allocation process had permanently failed so they can immediately take action and fail fast.

The `description` field should contain enough information that when logged, the failed host and failure reason can be determined quickly.

Reviewed By: pablorfb-meta

Differential Revision: D75880484
