### PR TITLE
small cleanup to monitoring code

### DIFF
--- a/hyperactor_mesh/src/proc_mesh/mod.rs
+++ b/hyperactor_mesh/src/proc_mesh/mod.rs
@@ -395,6 +395,19 @@ pub enum ProcEvent {
     Crashed(usize, String),
 }
 
+impl fmt::Display for ProcEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProcEvent::Stopped(rank, reason) => {
+                write!(f, "Proc at rank {} stopped: {}", rank, reason)
+            }
+            ProcEvent::Crashed(rank, reason) => {
+                write!(f, "Proc at rank {} crashed: {}", rank, reason)
+            }
+        }
+    }
+}
+
 /// An event stream of [`ProcEvent`]
 // TODO: consider using streams for this.
 pub struct ProcEvents {

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -92,13 +92,9 @@ impl PyProcMesh {
                 // A graceful stop should not be cause for alarm, but
                 // everything else should be considered a crash.
                 ProcEvent::Stopped(_, ProcStopReason::Stopped) => continue,
-                ProcEvent::Crashed(rank, reason) => {
-                    eprintln!("ProcMesh {} rank {} crashed: {}", world_id, rank, reason);
-                    std::process::exit(1);
-                }
-                ProcEvent::Stopped(rank, reason) => {
-                    eprintln!("ProcMesh {} rank {} crashed: {}", world_id, rank, reason);
-                    std::process::exit(1);
+                event => {
+                    eprintln!("ProcMesh {}: {}", world_id, event);
+                    std::process::exit(1)
                 }
             }
         }


### PR DESCRIPTION
Summary: Impl display for ProcEvent and use it, to avoid code duplication in the crashed path.

Reviewed By: vidhyav, mariusae

Differential Revision: D75975258


