### PR TITLE
Fix race condition in MockAllocWrapper

### DIFF
--- a/hyperactor_mesh/src/alloc/mod.rs
+++ b/hyperactor_mesh/src/alloc/mod.rs
@@ -239,7 +239,7 @@ pub mod test_utils {
         pub alloc: MockAlloc,
         pub block_next_after: usize,
         notify_tx: Sender<()>,
-        _notify_rx: Receiver<()>,
+        notify_rx: Receiver<()>,
         next_unblocked: bool,
     }
 
@@ -254,7 +254,7 @@ pub mod test_utils {
                 alloc,
                 block_next_after: count,
                 notify_tx: tx,
-                _notify_rx: rx,
+                notify_rx: rx,
                 next_unblocked: false,
             }
         }
@@ -270,8 +270,7 @@ pub mod test_utils {
             match self.block_next_after {
                 0 => {
                     if !self.next_unblocked {
-                        // resubscribe everytime as recv() gets cancelled
-                        self.notify_tx.subscribe().recv().await.unwrap();
+                        self.notify_rx.recv().await.unwrap();
                         self.next_unblocked = true;
                     }
                 }


### PR DESCRIPTION
Summary:
An unnecessary incorrect usage of broadcast channel created a race condition when `recv()` is cancelled and the struct member ends up receiving the unblock message.

The diff uses the struct local member instead.

Reviewed By: mariusae, suo

Differential Revision: D76277503


