### PR TITLE
Add setuptools-rust to requirements and pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ monarch.egg-info/*
 python/monarch/monarch_controller
 
 .ipynb_checkpoints
+.venv
 
 # Rust stuff
 target/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
-[tool.pytest.ini_options]
+[build-system]
+requires = ["setuptools", "setuptools-rust"]
+build-backend = "setuptools.build_meta"
 
+
+[tool.pytest.ini_options]
 markers = [
     "oss_skip: marks tests to skip in OSS CI",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy
 pyre-extensions
 cloudpickle
 torchx-nightly
+setuptools_rust


### PR DESCRIPTION
Trying to build fresh from scratch, noticed some dependencies were missing. I also wanted to use python's virtualenv to do the installation work to avoid installing a global torch version, so I added `.venv` to the .gitignore