### PR TITLE
subprocess and parallelize py tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,5 +64,5 @@ jobs:
         pip install --no-build-isolation .
 
         # Run tests
-        LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip"
+        LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" -n auto
         python python/tests/test_mock_cuda.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,5 @@ markers = [
     "oss_skip: marks tests to skip in OSS CI",
 ]
 asyncio_mode = "auto"
+# Default timeout of 5 minutes
+timeout = 300

--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-timeout
 pytest-asyncio
+pytest-xdist


### PR DESCRIPTION
Differential Revision: D76448556

- pytest-xdist will spin up a number of processes equal to CPU count and parallelizes the tests for a nice speed increase. it should also create some isolation (previously they all shared a single process context which increases the likelihood of state leaks)
  - let's monitor this and make sure it doesn't spin up hard to debug failures
- also setting a default timeout of 300s. don't think anything should ever take more than 5m...
