### PR TITLE
Update Bind/Unbind traits and impl them on PortRef

### DIFF
--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -71,29 +71,20 @@ enum PhilosopherMessage {
 
 // TODO(pzhang) replace the boilerplate Bind/Unbind impls with a macro.
 impl Bind for PhilosopherMessage {
-    fn bind(mut self, bindings: &Bindings) -> anyhow::Result<Self> {
-        match &mut self {
-            Self::Start(port) => {
-                let mut_ports = [port.port_id_mut()];
-                bindings.rebind(mut_ports.into_iter())?;
-            }
-            Self::GrantChopstick(_) => {}
+    fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
+        match self {
+            Self::Start(port) => port.bind(bindings),
+            Self::GrantChopstick(_) => Ok(()),
         }
-        Ok(self)
     }
 }
 
 impl Unbind for PhilosopherMessage {
-    fn bindings(&self) -> anyhow::Result<Bindings> {
-        let mut bindings = Bindings::default();
+    fn unbind(&self, bindings: &mut Bindings) -> anyhow::Result<()> {
         match self {
-            Self::Start(port) => {
-                let ports = [port.port_id()];
-                bindings.insert(ports)?;
-            }
-            Self::GrantChopstick(_) => {}
+            Self::Start(port) => port.unbind(bindings),
+            Self::GrantChopstick(_) => Ok(()),
         }
-        Ok(bindings)
     }
 }
 

--- a/hyperactor_mesh/src/test_utils.rs
+++ b/hyperactor_mesh/src/test_utils.rs
@@ -26,14 +26,14 @@ pub struct EmptyMessage();
 
 // TODO(pzhang) replace the boilerplate Bind/Unbind impls with a macro.
 impl Bind for EmptyMessage {
-    fn bind(self, _bindings: &Bindings) -> anyhow::Result<Self> {
-        Ok(self)
+    fn bind(&mut self, _bindings: &mut Bindings) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 
 impl Unbind for EmptyMessage {
-    fn bindings(&self) -> anyhow::Result<Bindings> {
-        Ok(Bindings::default())
+    fn unbind(&self, _bindings: &mut Bindings) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 

--- a/monarch_messages/src/worker.rs
+++ b/monarch_messages/src/worker.rs
@@ -845,14 +845,14 @@ pub enum WorkerMessage {
 // WorkerMessage currently has no accumulation reply port.
 // TODO(pzhang) add macro to auto implement these traits.
 impl Unbind for WorkerMessage {
-    fn bindings(&self) -> anyhow::Result<Bindings> {
-        Ok(Bindings::default())
+    fn unbind(&self, _bindings: &mut Bindings) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 
 impl Bind for WorkerMessage {
-    fn bind(self, _bindings: &Bindings) -> anyhow::Result<Self> {
-        Ok(self)
+    fn bind(&mut self, _bindings: &mut Bindings) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 

--- a/monarch_rdma/examples/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server.rs
@@ -150,14 +150,14 @@ struct Log;
 
 // TODO(pzhang) replace the boilerplate Bind/Unbind impls with a macro.
 impl Bind for Log {
-    fn bind(self, _bindings: &Bindings) -> anyhow::Result<Self> {
-        Ok(self)
+    fn bind(&mut self, _bindings: &mut Bindings) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 
 impl Unbind for Log {
-    fn bindings(&self) -> anyhow::Result<Bindings> {
-        Ok(Bindings::default())
+    fn unbind(&self, _bindings: &mut Bindings) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 
@@ -307,14 +307,14 @@ pub struct WorkerInit(
 
 // TODO(pzhang) replace the boilerplate Bind/Unbind impls with a macro.
 impl Bind for WorkerInit {
-    fn bind(self, _bindings: &Bindings) -> anyhow::Result<Self> {
-        Ok(self)
+    fn bind(&mut self, _bindings: &mut Bindings) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 
 impl Unbind for WorkerInit {
-    fn bindings(&self) -> anyhow::Result<Bindings> {
-        Ok(Bindings::default())
+    fn unbind(&self, _bindings: &mut Bindings) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 
@@ -327,19 +327,14 @@ pub struct WorkerStep(PortRef<bool>);
 
 // TODO(pzhang) replace the boilerplate Bind/Unbind impls with a macro.
 impl Bind for WorkerStep {
-    fn bind(mut self, bindings: &Bindings) -> anyhow::Result<Self> {
-        let mut_ports = [self.0.port_id_mut()];
-        bindings.rebind(mut_ports.into_iter())?;
-        Ok(self)
+    fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
+        self.0.bind(bindings)
     }
 }
 
 impl Unbind for WorkerStep {
-    fn bindings(&self) -> anyhow::Result<Bindings> {
-        let mut bindings = Bindings::default();
-        let ports = [self.0.port_id()];
-        bindings.insert(ports)?;
-        Ok(bindings)
+    fn unbind(&self, bindings: &mut Bindings) -> anyhow::Result<()> {
+        self.0.unbind(bindings)
     }
 }
 
@@ -352,19 +347,14 @@ pub struct WorkerUpdate(PortRef<bool>);
 
 // TODO(pzhang) replace the boilerplate Bind/Unbind impls with a macro.
 impl Bind for WorkerUpdate {
-    fn bind(mut self, bindings: &Bindings) -> anyhow::Result<Self> {
-        let mut_ports = [self.0.port_id_mut()];
-        bindings.rebind(mut_ports.into_iter())?;
-        Ok(self)
+    fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
+        self.0.bind(bindings)
     }
 }
 
 impl Unbind for WorkerUpdate {
-    fn bindings(&self) -> anyhow::Result<Bindings> {
-        let mut bindings = Bindings::default();
-        let ports = [self.0.port_id()];
-        bindings.insert(ports)?;
-        Ok(bindings)
+    fn unbind(&self, bindings: &mut Bindings) -> anyhow::Result<()> {
+        self.0.unbind(bindings)
     }
 }
 

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -284,14 +284,14 @@ pub enum AssignRankMessage {
 
 // TODO(pzhang) replace the boilerplate Bind/Unbind impls with a macro.
 impl Bind for AssignRankMessage {
-    fn bind(self, _bindings: &Bindings) -> anyhow::Result<Self> {
-        Ok(self)
+    fn bind(&mut self, _bindings: &mut Bindings) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 
 impl Unbind for AssignRankMessage {
-    fn bindings(&self) -> anyhow::Result<Bindings> {
-        Ok(Bindings::default())
+    fn unbind(&self, _bindings: &mut Bindings) -> anyhow::Result<()> {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Summary: As suggested by mariusae in several diff comments, delegating to the common types, such as `PortRef` result in simpler code, and make it easier to support generics.

Differential Revision: D76443249
