### PR TITLE
remove flaky remote function failure

### DIFF
--- a/python/monarch/builtins/random.py
+++ b/python/monarch/builtins/random.py
@@ -16,11 +16,6 @@ def set_manual_seed_remote(seed: int, process_idx: int = 0) -> None:
     torch.manual_seed(seed ^ process_idx)
 
 
-@remote(propagate=lambda: 0)
-def initial_seed_remote() -> int:
-    return torch.initial_seed()
-
-
 @remote(propagate=lambda: torch.zeros(1))
 def get_rng_state_remote() -> torch.Tensor:
     return torch.get_rng_state()
@@ -67,3 +62,7 @@ def get_rng_state_all_cuda_remote() -> list[torch.Tensor]:
 @remote(propagate="inspect")
 def set_rng_state_all_cuda_remote(states: list[torch.Tensor]) -> None:
     torch.cuda.set_rng_state_all(states)
+
+
+# initial_seed may sometimes return a uint64 which currenly can't be unwrapped by the framework
+# def initial_seed_remote() -> int: ...

--- a/python/tests/builtins/test_random.py
+++ b/python/tests/builtins/test_random.py
@@ -13,7 +13,6 @@ from monarch._testing import BackendType, TestingContext
 from monarch.builtins.random import (
     get_rng_state_all_cuda_remote,
     get_rng_state_remote,
-    initial_seed_remote,
     manual_seed_all_cuda_remote,
     manual_seed_cuda_remote,
     random_seed_remote,
@@ -77,15 +76,6 @@ class TestRandomFunctions:
                 result = fetch_shard((t1, t2)).result()
                 with no_mesh.activate():
                     assert not torch.equal(result[0], result[1])
-
-    def test_initial_seed_remote(self, backend_type):
-        with self.local_device_mesh(1, 1, backend_type) as device_mesh:
-            with device_mesh.activate():
-                seed_value = initial_seed_remote()
-
-                result = fetch_shard(seed_value).result()
-                with no_mesh.activate():
-                    assert isinstance(result, int)
 
     def test_get_rng_state(self, backend_type):
         with self.local_device_mesh(1, 1, backend_type) as device_mesh:


### PR DESCRIPTION
Summary: Initial seed is sometimes a uint64, meaning we can't reliably wrap it in a tensor or return it directly from the remote function. removing it until this support is possible directly from remote functions

Reviewed By: colin2328

Differential Revision: D76479462
