### PR TITLE
Return records when simulator is closed

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -612,7 +612,6 @@ mod tests {
     use hyperactor::RefClient;
     use hyperactor::channel;
     use hyperactor::channel::ChannelTransport;
-    use hyperactor::channel::sim;
     use hyperactor::channel::sim::SimAddr;
     use hyperactor::clock::Clock;
     use hyperactor::clock::RealClock;
@@ -631,6 +630,7 @@ mod tests {
     use hyperactor::reference::GangId;
     use hyperactor::reference::ProcId;
     use hyperactor::reference::WorldId;
+    use hyperactor::simnet;
     use hyperactor_mesh::comm::CommActorParams;
     use hyperactor_multiprocess::System;
     use hyperactor_multiprocess::proc_actor::ProcMessage;
@@ -1549,6 +1549,15 @@ mod tests {
         // Start system actor.
         let system_addr = ChannelAddr::any(ChannelTransport::Unix);
         let proxy_addr = ChannelAddr::any(ChannelTransport::Unix);
+        simnet::start(
+            ChannelAddr::any(ChannelTransport::Unix),
+            proxy_addr.clone(),
+            1000,
+        )
+        .unwrap();
+        simnet::simnet_handle()
+            .unwrap()
+            .set_training_script_state(simnet::TrainingScriptState::Waiting);
 
         let system_sim_addr =
             ChannelAddr::Sim(SimAddr::new(system_addr, proxy_addr.clone()).unwrap());
@@ -1647,7 +1656,7 @@ mod tests {
         assert_eq!(result.0, Seq::default());
         assert!(result.1.expect("result").is_err());
 
-        let records = sim::records().await.unwrap();
+        let records = simnet::simnet_handle().unwrap().close().await.unwrap();
         eprintln!("{}", serde_json::to_string_pretty(&records).unwrap());
     }
     #[tokio::test]

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -223,11 +223,6 @@ impl Event for MessageDeliveryEvent {
     }
 }
 
-/// Export the message delivery records of the simnet.
-pub async fn records() -> anyhow::Result<Option<Vec<simnet::SimulatorEventRecord>>, SimNetError> {
-    Ok(simnet_handle()?.records().await)
-}
-
 /// Bind a channel address to the simnet. It will register the address as a node in simnet,
 /// and configure default latencies between this node and all other existing nodes.
 pub async fn bind(addr: ChannelAddr) -> anyhow::Result<(), SimNetError> {
@@ -539,7 +534,7 @@ mod tests {
             assert_eq!(rx.recv().await.unwrap(), 123);
         }
 
-        let records = sim::records().await;
+        let records = sim::simnet_handle().unwrap().close().await.unwrap();
         eprintln!("records: {:#?}", records);
     }
 
@@ -768,7 +763,7 @@ mod tests {
             // Allow some time for simnet to run
             RealClock.sleep(tokio::time::Duration::from_secs(1)).await;
         }
-        let recs = records().await.unwrap().unwrap();
+        let recs = simnet::simnet_handle().unwrap().close().await.unwrap();
         assert_eq!(recs.len(), 2);
         let end_times = recs.iter().map(|rec| rec.end_at).collect::<Vec<_>>();
         // client message was delivered at "real" time = 5 seconds

--- a/hyperactor/src/channel/sim.rs
+++ b/hyperactor/src/channel/sim.rs
@@ -698,8 +698,8 @@ mod tests {
         // This message will be delievered at simulator time = 100 seconds
         tx.try_post((), oneshot::channel().0).unwrap();
         {
-            // Allow some time for simnet to run
-            RealClock.sleep(tokio::time::Duration::from_secs(1)).await;
+            // Allow simnet to run
+            tokio::task::yield_now().await;
             // Messages have not been receive since 10 seconds have not elapsed
             assert!(rx.rx.try_recv().is_err());
         }
@@ -707,7 +707,7 @@ mod tests {
         tokio::time::advance(tokio::time::Duration::from_secs(100)).await;
         {
             // Allow some time for simnet to run
-            RealClock.sleep(tokio::time::Duration::from_secs(1)).await;
+            tokio::task::yield_now().await;
             // Messages are received
             assert!(rx.rx.try_recv().is_ok());
         }

--- a/hyperactor_multiprocess/src/ping_pong.rs
+++ b/hyperactor_multiprocess/src/ping_pong.rs
@@ -115,7 +115,7 @@ edges:
 
         assert!(done_rx.recv().await.unwrap());
 
-        let records = sim::records().await.unwrap();
+        let records = simnet::simnet_handle().unwrap().close().await.unwrap();
         eprintln!(
             "records: {}",
             serde_json::to_string_pretty(&records).unwrap()


### PR DESCRIPTION
Summary: Instead of wrapping the records in an Option<Arc<Mutex>> to be shared between the SimnetHandle and the Simnet and moved out when requested, we can just have the Simnet fully own the records and return them when the event loop is completed

Reviewed By: kaiyuan-li

Differential Revision: D76433476
