### PR TITLE
Add python accumulator and reducer

### DIFF
--- a/hyperactor/src/cap.rs
+++ b/hyperactor/src/cap.rs
@@ -33,6 +33,7 @@ pub(crate) mod sealed {
     use async_trait::async_trait;
 
     use crate::PortId;
+    use crate::accum::ReducerSpec;
     use crate::actor::Actor;
     use crate::actor::ActorHandle;
     use crate::attrs::Attrs;
@@ -48,7 +49,11 @@ pub(crate) mod sealed {
     }
 
     pub trait CanSplitPort: Send + Sync {
-        fn split(&self, port_id: PortId, reducer: Option<u64>) -> PortId;
+        fn split(
+            &self,
+            port_id: PortId,
+            reducer_spec: Option<ReducerSpec>,
+        ) -> anyhow::Result<PortId>;
     }
 
     #[async_trait]

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -313,6 +313,7 @@ mod tests {
     use hyperactor::id;
 
     use super::*;
+    use crate::accum::ReducerSpec;
     use crate::reference::UnboundPort;
 
     // Used to demonstrate a user defined reply type.
@@ -349,7 +350,13 @@ mod tests {
     #[test]
     fn test_castable() {
         let original_port0 = PortRef::attest(id!(world[0].actor[0][123]));
-        let original_port1 = PortRef::attest_reducible(id!(world[1].actor1[0][456]), Some(123));
+        let original_port1 = PortRef::attest_reducible(
+            id!(world[1].actor1[0][456]),
+            Some(ReducerSpec {
+                typehash: 123,
+                builder_params: None,
+            }),
+        );
         let my_message = MyMessage {
             arg0: true,
             arg1: 42,
@@ -398,7 +405,13 @@ mod tests {
             .unwrap();
 
         let new_port0 = PortRef::<String>::attest(new_port_id0);
-        let new_port1 = PortRef::<MyReply>::attest_reducible(new_port_id1, Some(123));
+        let new_port1 = PortRef::<MyReply>::attest_reducible(
+            new_port_id1,
+            Some(ReducerSpec {
+                typehash: 123,
+                builder_params: None,
+            }),
+        );
         let new_bindings = Bindings(
             [
                 (

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -52,6 +52,7 @@ use crate::Handler;
 use crate::Message;
 use crate::Named;
 use crate::RemoteMessage;
+use crate::accum::ReducerSpec;
 use crate::actor::ActorError;
 use crate::actor::ActorErrorKind;
 use crate::actor::ActorHandle;
@@ -1230,8 +1231,8 @@ impl<A: Actor> cap::sealed::CanOpenPort for Instance<A> {
 }
 
 impl<A: Actor> cap::sealed::CanSplitPort for Instance<A> {
-    fn split(&self, port_id: PortId, reducer_typehash: Option<u64>) -> PortId {
-        self.mailbox.split(port_id, reducer_typehash)
+    fn split(&self, port_id: PortId, reducer_spec: Option<ReducerSpec>) -> anyhow::Result<PortId> {
+        self.mailbox.split(port_id, reducer_spec)
     }
 }
 

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -813,7 +813,7 @@ impl<M: RemoteMessage> PortRef<M> {
 
     /// The caller attests that the provided PortId can be
     /// converted to a reachable, typed port reference.
-    pub(crate) fn attest_reducible(port_id: PortId, reducer_spec: Option<ReducerSpec>) -> Self {
+    pub fn attest_reducible(port_id: PortId, reducer_spec: Option<ReducerSpec>) -> Self {
         Self {
             port_id,
             reducer_spec,

--- a/hyperactor_mesh/src/comm/mod.rs
+++ b/hyperactor_mesh/src/comm/mod.rs
@@ -186,8 +186,8 @@ impl CommActor {
         // of to the original ports provided by parent.
         message
             .data_mut()
-            .visit_mut::<UnboundPort>(|UnboundPort(port_id, reducer_typehash)| {
-                let split = port_id.split(this, reducer_typehash.clone());
+            .visit_mut::<UnboundPort>(|UnboundPort(port_id, reducer_spec)| {
+                let split = port_id.split(this, reducer_spec.clone())?;
 
                 #[cfg(test)]
                 tests::collect_split_port(port_id, &split, deliver_here);
@@ -509,7 +509,7 @@ mod tests {
     use hyperactor::PortRef;
     use hyperactor::accum;
     use hyperactor::accum::Accumulator;
-    use hyperactor::accum::CommReducer;
+    use hyperactor::accum::ReducerSpec;
     use hyperactor::clock::Clock;
     use hyperactor::clock::RealClock;
     use hyperactor::config;
@@ -703,25 +703,21 @@ mod tests {
         reply_tos: Vec<(PortRef<u64>, PortRef<MyReply>)>,
     }
 
-    // Placeholder to make compiler happy.
-    #[derive(Debug, Clone, Serialize, Deserialize, Named)]
-    struct NonReducer;
-    impl CommReducer for NonReducer {
-        type Update = u64;
-
-        fn reduce(&self, _left: Self::Update, _right: Self::Update) -> Self::Update {
-            unimplemented!()
-        }
-    }
-
     struct NoneAccumulator;
 
     impl Accumulator for NoneAccumulator {
         type State = u64;
         type Update = u64;
-        type Reducer = NonReducer;
 
-        fn accumulate(&self, _state: &mut Self::State, _update: Self::Update) {
+        fn accumulate(
+            &self,
+            _state: &mut Self::State,
+            _update: Self::Update,
+        ) -> anyhow::Result<()> {
+            unimplemented!()
+        }
+
+        fn reducer_spec(&self) -> Option<ReducerSpec> {
             unimplemented!()
         }
     }

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -47,8 +47,6 @@ pub struct CastMessageEnvelope {
     dest_port: DestinationPort,
     /// The serialized message.
     data: ErasedUnbound,
-    /// typehash of the reducer used to accumulate the message in split ports.
-    pub reducer_typehash: Option<u64>,
 }
 
 impl CastMessageEnvelope {
@@ -57,14 +55,12 @@ impl CastMessageEnvelope {
         sender: ActorId,
         dest_port: DestinationPort,
         message: T,
-        reducer_typehash: Option<u64>,
     ) -> Result<Self, anyhow::Error> {
         let data = ErasedUnbound::try_from_message(message)?;
         Ok(Self {
             sender,
             dest_port,
             data,
-            reducer_typehash,
         })
     }
 
@@ -76,7 +72,6 @@ impl CastMessageEnvelope {
             sender,
             dest_port,
             data: ErasedUnbound::new(data),
-            reducer_typehash: None,
         }
     }
 
@@ -90,10 +85,6 @@ impl CastMessageEnvelope {
 
     pub(crate) fn data_mut(&mut self) -> &mut ErasedUnbound {
         &mut self.data
-    }
-
-    pub(crate) fn reducer_typehash(&self) -> &Option<u64> {
-        &self.reducer_typehash
     }
 }
 

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -17,6 +17,7 @@ hyperactor_extension = { version = "0.0.0", path = "../hyperactor_extension" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
+inventory = "0.3.8"
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 pyo3 = { version = "0.24", features = ["anyhow"] }

--- a/monarch_types/src/pyobject.rs
+++ b/monarch_types/src/pyobject.rs
@@ -15,23 +15,40 @@ use serde::Serialize;
 use crate::TryIntoPyObject;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Named)]
-pub struct PickledPyObject(#[serde(with = "serde_bytes")] Vec<u8>);
+pub struct PickledPyObject {
+    #[serde(with = "serde_bytes")]
+    bytes: Vec<u8>,
+    cloudpickle: bool,
+}
 
 impl PickledPyObject {
     pub fn pickle<'py>(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        Self::pickle_impl(obj, false)
+    }
+
+    pub fn cloudpickle<'py>(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+        Self::pickle_impl(obj, true)
+    }
+
+    fn module(cloudpickle: bool) -> &'static str {
+        if cloudpickle { "cloudpickle" } else { "pickle" }
+    }
+
+    fn pickle_impl<'py>(obj: &Bound<'py, PyAny>, cloudpickle: bool) -> PyResult<Self> {
+        let module = Self::module(cloudpickle);
         let bytes = obj
             .py()
-            .import("pickle")?
+            .import(module)?
             .call_method1("dumps", (obj,))?
             .downcast_into::<PyBytes>()?
             .as_bytes()
             .to_vec();
-        Ok(Self(bytes))
+        Ok(Self { bytes, cloudpickle })
     }
 
     pub fn unpickle<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py.import("pickle")?
-            .call_method1("loads", (self.0.as_slice(),))
+        py.import(Self::module(self.cloudpickle))?
+            .call_method1("loads", (self.bytes.as_slice(),))
     }
 }
 

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -1,0 +1,164 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import asyncio
+import pickle
+from typing import Callable, cast, final, Generic, TypeVar
+
+import monarch
+
+from monarch._rust_bindings.hyperactor_extension.alloc import (
+    AllocConstraints,
+    AllocSpec,
+)
+
+from monarch._rust_bindings.monarch_hyperactor.actor import PanicFlag, PythonMessage
+
+from monarch._rust_bindings.monarch_hyperactor.mailbox import (
+    Mailbox,
+    PortReceiver,
+    PortRef,
+)
+from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
+from monarch._rust_bindings.monarch_hyperactor.shape import Shape
+
+
+S = TypeVar("S")
+U = TypeVar("U")
+
+
+@final
+class Reducer(Generic[U]):
+    def __init__(
+        self,
+        reduce_f: Callable[[U, U], U],
+    ) -> None:
+        self._reduce_f: Callable[[U, U], U] = reduce_f
+
+    def __call__(self, left: PythonMessage, right: PythonMessage) -> PythonMessage:
+        l: U = cast(U, pickle.loads(left.message))
+        r: U = cast(U, pickle.loads(right.message))
+        result: U = self._reduce_f(l, r)
+        return PythonMessage(left.method, pickle.dumps(result), None, None)
+
+
+@final
+class Accumulator(Generic[S, U]):
+    def __init__(
+        self,
+        initial_state: S,
+        accumulate_f: Callable[[S, U], S],
+        reduce_f: Callable[[U, U], U] | None,
+    ) -> None:
+        self._initial_state: S = initial_state
+        self._accumulate_f: Callable[[S, U], S] = accumulate_f
+        self._reducer: Reducer[U] | None = (
+            Reducer(reduce_f) if reduce_f is not None else None
+        )
+
+    def __call__(self, state: PythonMessage, update: PythonMessage) -> PythonMessage:
+        s: S = cast(S, pickle.loads(state.message))
+        u: U = cast(U, pickle.loads(update.message))
+        result: S = self._accumulate_f(s, u)
+        return PythonMessage(state.method, pickle.dumps(result), None, None)
+
+    @property
+    def initial_state(self) -> PythonMessage:
+        return PythonMessage(
+            " @Accumulator.initial_state", pickle.dumps(self._initial_state), None, None
+        )
+
+    @property
+    def reducer(self) -> Reducer[U] | None:
+        return self._reducer
+
+
+async def allocate() -> ProcMesh:
+    spec = AllocSpec(AllocConstraints(), replica=1)
+    allocator = monarch.LocalAllocator()
+    alloc = await allocator.allocate(spec)
+    proc_mesh = await ProcMesh.allocate_nonblocking(alloc)
+    return proc_mesh
+
+
+async def test_accumulator() -> None:
+    proc_mesh = await allocate()
+    mailbox: Mailbox = proc_mesh.client
+
+    def my_accumulate(state: str, update: int) -> str:
+        return f"{state}+{update}"
+
+    accumulator = Accumulator("init", my_accumulate, None)
+    receiver: PortReceiver
+    handle, receiver = mailbox.open_accum_port(accumulator)
+    port_ref: PortRef = handle.bind()
+
+    def post_message(value: int) -> None:
+        port_ref.send(
+            mailbox, PythonMessage("test_accumulator", pickle.dumps(value), None, None)
+        )
+
+    async def recv_message() -> str:
+        messge = await asyncio.wait_for(receiver.recv(), timeout=5)
+        value = pickle.loads(messge.message)
+        return cast(str, value)
+
+    post_message(1)
+    # Receive the first message
+    assert await recv_message() == "init+1"
+
+    post_message(2)
+    post_message(3)
+    post_message(4)
+    # Receive the 2nd to 4th messages
+    assert await recv_message() == "init+1+2+3+4"
+
+
+class MyActor:
+    async def handle(
+        self, mailbox: Mailbox, message: PythonMessage, panic_flag: PanicFlag
+    ) -> None:
+        return None
+
+    async def handle_cast(
+        self,
+        mailbox: Mailbox,
+        rank: int,
+        shape: Shape,
+        message: PythonMessage,
+        panic_flag: PanicFlag,
+    ) -> None:
+        assert message.response_port is not None
+        reply_port = message.response_port
+        reply_port.send(mailbox, PythonMessage("echo", message.message, None, None))
+        for i in range(100):
+            reply_port.send(
+                mailbox, PythonMessage("echo", pickle.dumps(f"msg{i}"), None, None)
+            )
+
+
+async def test_reducer() -> None:
+    proc_mesh = await allocate()
+    actor_mesh = await proc_mesh.spawn_nonblocking("test", MyActor)
+
+    def my_accumulate(state: str, update: str) -> str:
+        return state + update
+
+    def my_reduce(state: str, update: str) -> str:
+        return f"[reduced]({state}+{update})"
+
+    accumulator = Accumulator("", my_accumulate, my_reduce)
+    receiver: PortReceiver
+    handle, receiver = proc_mesh.client.open_accum_port(accumulator)
+    port_ref = handle.bind()
+
+    actor_mesh.cast(PythonMessage("echo", pickle.dumps("start"), port_ref, None))
+
+    messge = await asyncio.wait_for(receiver.recv(), timeout=5)
+    value = cast(str, pickle.loads(messge.message))
+    assert "[reduced](start+msg0)" in value


### PR DESCRIPTION
Summary:
We want to define accumulator and reducer in python, and run them in the Rust backend. This diff adds that.

Specifically, the implementation follows the patten established by `PythonActor`. The change consists of:

1. A rust `struct PythonAccumulator`, which is the container of 2 Python functions, one for accumulation and one for reduction.
2. A rust `PythonReducer`, which contains 1 Python function which is used for reduction.

The `struct PythonAccumulator` is bound to Python, and thus can take the Python functions in as parameters.

Differential Revision: D76156297
