### PR TITLE
[ndslice]: selection: normal: implement flattening

### DIFF
--- a/ndslice/src/selection/mod.rs
+++ b/ndslice/src/selection/mod.rs
@@ -109,6 +109,7 @@ use serde::Serialize;
 
 use crate::Slice;
 use crate::selection::normal::NormalizedSelection;
+use crate::selection::normal::RewriteRuleExt;
 use crate::shape;
 use crate::shape::ShapeError;
 use crate::slice::SliceError;
@@ -358,7 +359,7 @@ pub fn structurally_equal(a: &Selection, b: &Selection) -> bool {
 /// structure. It is designed to improve over time as additional
 /// rewrites (e.g., flattening, simplification) are introduced.
 pub fn normalize(sel: &Selection) -> NormalizedSelection {
-    let rule = normal::IdentityRules;
+    let rule = normal::FlatteningRules.then(normal::IdentityRules);
     sel.fold::<normal::NormalizedSelection>()
         .rewrite_bottom_up(&rule)
 }


### PR DESCRIPTION
adds `FlatteningRules` to flatten nested unions/intersections and fluent rule composition via `RewriteRuleExt.then()`. updates `normalize()` to apply flattening before identity rules.