### PR TITLE
fix "most" deprecation warnings

### DIFF
--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -23,7 +23,7 @@ hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiproces
 monarch_messages = { version = "0.0.0", path = "../monarch_messages" }
 nccl-sys = { path = "../nccl-sys" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
-pyo3 = { version = "0.22.6", features = ["anyhow"] }
+pyo3 = { version = "0.24", features = ["anyhow"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["float_roundtrip", "unbounded_depth"] }
 tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }

--- a/hyperactor_extension/Cargo.toml
+++ b/hyperactor_extension/Cargo.toml
@@ -12,5 +12,5 @@ async-trait = "0.1.86"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
-pyo3 = { version = "0.22.6", features = ["anyhow"] }
+pyo3 = { version = "0.24", features = ["anyhow"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -28,7 +28,7 @@ monarch_tensor_worker = { version = "0.0.0", path = "../monarch_tensor_worker", 
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
 nccl-sys = { path = "../nccl-sys", optional = true }
 ndslice = { version = "0.0.0", path = "../ndslice" }
-pyo3 = { version = "0.22.6", features = ["anyhow"] }
+pyo3 = { version = "0.24", features = ["anyhow"] }
 tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }
 torch-sys = { version = "0.0.0", path = "../torch-sys", optional = true }
 torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda", optional = true }

--- a/monarch_extension/src/debugger.rs
+++ b/monarch_extension/src/debugger.rs
@@ -62,7 +62,7 @@ pub fn get_bytes_from_write_action(
     action: DebuggerAction,
 ) -> PyResult<Bound<'_, PyBytes>> {
     if let DebuggerAction::Write { bytes } = action {
-        Ok(PyBytes::new_bound(py, &bytes))
+        Ok(PyBytes::new(py, &bytes))
     } else {
         Err(PyRuntimeError::new_err(format!(
             "Cannot extract bytes from non-write debugger action {:?}",
@@ -115,7 +115,7 @@ impl PdbActor {
             )?;
         match result {
             Ok(Some(DebuggerMessage::Action { action })) => Ok(action.into_py(py)),
-            Ok(None) => Ok(PyNone::get_bound(py).into_py(py)),
+            Ok(None) => Ok(PyNone::get(py).into_py(py)),
             Err(err) => Err(PyRuntimeError::new_err(err.to_string())),
         }
     }

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -42,11 +42,11 @@ fn get_or_add_new_module<'py>(
         if let Some(submodule) = submodule {
             current_module = submodule.extract()?;
         } else {
-            let new_module = PyModule::new_bound(current_module.py(), part)?;
+            let new_module = PyModule::new(current_module.py(), part)?;
             current_module.add_submodule(&new_module)?;
             current_module
                 .py()
-                .import_bound("sys")?
+                .import("sys")?
                 .getattr("modules")?
                 .set_item(
                     format!("monarch._rust_bindings.{}", parts.join(".")),

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -187,10 +187,10 @@ impl _Controller {
     ) -> PyResult<()> {
         let failures = self.history.add_invocation(
             seq.into(),
-            uses.iter()?
+            uses.try_iter()?
                 .map(|x| Ref::from_py_object(&x?))
                 .collect::<PyResult<Vec<Ref>>>()?,
-            defs.iter()?
+            defs.try_iter()?
                 .map(|x| Ref::from_py_object(&x?))
                 .collect::<PyResult<Vec<Ref>>>()?,
         );

--- a/monarch_extension/src/tensor_worker.rs
+++ b/monarch_extension/src/tensor_worker.rs
@@ -1265,7 +1265,7 @@ fn wire_values_to_args(py: Python<'_>, args: Vec<WireValue>) -> PyResult<PyObjec
             }
         })
         .collect::<Result<Vec<_>, PyErr>>()?;
-    Ok(PyTuple::new_bound(py, py_ags).to_object(py))
+    Ok(PyTuple::new(py, py_ags)?.into())
 }
 
 fn wire_values_to_kwargs(py: Python<'_>, kwargs: HashMap<String, WireValue>) -> PyResult<PyObject> {
@@ -1378,7 +1378,7 @@ pub(crate) fn worker_message_to_py(py: Python<'_>, message: &WorkerMessage) -> P
 /// during packaging.
 #[pyfunction]
 fn worker_main(py: Python<'_>) -> PyResult<()> {
-    let argv: Vec<String> = py.import_bound("sys")?.getattr("argv")?.extract()?;
+    let argv: Vec<String> = py.import("sys")?.getattr("argv")?.extract()?;
     Python::allow_threads(py, move || {
         let args = BinaryArgs::parse_from(argv);
 

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -19,8 +19,8 @@ hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiproces
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
-pyo3 = { version = "0.22.6", features = ["anyhow"] }
-pyo3-async-runtimes = { git = "https://github.com/PyO3/pyo3-async-runtimes", rev = "f6bb9b471a5b7765dd770af36e83f26802459621", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.24", features = ["anyhow"] }
+pyo3-async-runtimes = { git = "https://github.com/PyO3/pyo3-async-runtimes", rev = "c5a3746f110b4d246556b0f6c29f5f555919eee3", features = ["attributes", "tokio-runtime"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 thiserror = "2.0.12"

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -86,7 +86,7 @@ impl PickledMessage {
 
     #[getter]
     fn message<'a>(&self, py: Python<'a>) -> Bound<'a, PyBytes> {
-        PyBytes::new_bound(py, self.message.as_ref())
+        PyBytes::new(py, self.message.as_ref())
     }
 
     fn serialize(&self) -> PyResult<PySerialized> {
@@ -144,7 +144,7 @@ impl PickledMessageClientActor {
             .into_iter()
             .map(|message| message.into_py(py))
             .collect::<Vec<PyObject>>();
-        Ok(PyList::new_bound(py, messages))
+        PyList::new(py, messages)
     }
 
     fn world_status<'py>(&mut self, py: Python<'py>) -> PyResult<PyObject> {
@@ -154,7 +154,7 @@ impl PickledMessageClientActor {
             instance.lock().await.world_status(Default::default()).await
         })??;
         Python::with_gil(|py| {
-            let py_dict = PyDict::new_bound(py);
+            let py_dict = PyDict::new(py);
             for (world, status) in worlds {
                 py_dict.set_item(world.to_string(), status.to_string())?;
             }
@@ -234,7 +234,7 @@ impl PythonMessage {
 
     #[getter]
     fn message<'a>(&self, py: Python<'a>) -> Bound<'a, PyBytes> {
-        PyBytes::new_bound(py, self.message.as_ref())
+        PyBytes::new(py, self.message.as_ref())
     }
 
     #[getter]
@@ -351,7 +351,7 @@ fn get_task_locals(py: Python) -> &'static pyo3_async_runtimes::TaskLocals {
             let (tx, rx) = std::sync::mpsc::channel();
             let _ = std::thread::spawn(move || {
                 Python::with_gil(|py| {
-                    let asyncio = Python::import_bound(py, "asyncio").unwrap();
+                    let asyncio = Python::import(py, "asyncio").unwrap();
                     let event_loop = asyncio.call_method0("new_event_loop").unwrap();
                     asyncio
                         .call_method1("set_event_loop", (event_loop.clone(),))
@@ -466,7 +466,7 @@ impl Handler<PythonMessage> for PythonActor {
                 inner: this.mailbox_for_py().clone(),
             };
             let awaitable = tokio::task::block_in_place(|| {
-                self.actor.call_method_bound(
+                self.actor.call_method(
                     py,
                     "handle",
                     (
@@ -519,7 +519,7 @@ impl Handler<Cast<PythonMessage>> for PythonActor {
             };
 
             let awaitable = tokio::task::block_in_place(|| {
-                self.actor.call_method_bound(
+                self.actor.call_method(
                     py,
                     "handle_cast",
                     (

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -54,10 +54,7 @@ impl PyMailbox {
                 inner: Arc::new(tokio::sync::Mutex::new(receiver)),
             },
         )?;
-        Ok(PyTuple::new_bound(
-            py,
-            vec![handle.into_any(), receiver.into_any()],
-        ))
+        PyTuple::new(py, vec![handle.into_any(), receiver.into_any()])
     }
 
     fn open_once_port<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
@@ -74,10 +71,7 @@ impl PyMailbox {
                 inner: std::sync::Mutex::new(Some(receiver)),
             },
         )?;
-        Ok(PyTuple::new_bound(
-            py,
-            vec![handle.into_any(), receiver.into_any()],
-        ))
+        PyTuple::new(py, vec![handle.into_any(), receiver.into_any()])
     }
 
     pub(super) fn post<'py>(

--- a/monarch_hyperactor/src/ndslice.rs
+++ b/monarch_hyperactor/src/ndslice.rs
@@ -120,7 +120,7 @@ impl PySlice {
                     );
                     i += step;
                 }
-                Ok(PyTuple::new_bound(py, result).into_py(py))
+                Ok(PyTuple::new(py, result)?.into_py(py))
             }
         }
     }
@@ -133,16 +133,16 @@ impl PySlice {
         self.inner.len()
     }
 
-    fn __getnewargs_ex__<'py>(&self, py: Python<'py>) -> Bound<'py, PyTuple> {
-        let kwargs = PyDict::new_bound(py);
+    fn __getnewargs_ex__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
+        let kwargs = PyDict::new(py);
         kwargs.set_item("offset", self.inner.offset()).unwrap();
         kwargs.set_item("sizes", self.inner.sizes()).unwrap();
         kwargs.set_item("strides", self.inner.strides()).unwrap();
 
-        PyTuple::new_bound(
+        PyTuple::new(
             py,
             vec![
-                PyTuple::empty_bound(py).unbind().into_any(),
+                PyTuple::empty(py).unbind().into_any(),
                 kwargs.unbind().into_any(),
             ],
         )
@@ -166,7 +166,7 @@ impl PySlice {
     #[staticmethod]
     fn from_list(py: Python<'_>, ranks: Vec<usize>) -> PyResult<PyObject> {
         if ranks.is_empty() {
-            return Ok(PyList::empty_bound(py).unbind().into_any());
+            return Ok(PyList::empty(py).unbind().into_any());
         }
         let mut ranks = ranks;
         ranks.sort();

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -125,7 +125,7 @@ impl PyProc {
             .collect::<Vec<_>>();
         // TODO: i don't think returning this list is of much use for
         // anything?
-        Ok(PyList::new_bound(py, aborted_actors))
+        PyList::new(py, aborted_actors)
     }
 
     #[pyo3(signature = (actor, name=None))]

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -39,7 +39,7 @@ pub fn initialize(py: Python) -> Result<()> {
         .map_err(|_| anyhow!("failed to initialize py3 async runtime"))?;
 
     // Initialize thread local state to identify the main Python thread.
-    let threading = Python::import_bound(py, "threading")?;
+    let threading = Python::import(py, "threading")?;
     let main_thread = threading.call_method0("main_thread")?;
     let current_thread = threading.getattr("current_thread")?.call0()?;
     ensure!(
@@ -125,7 +125,7 @@ pub fn sleep_indefinitely_for_unit_tests(py: Python) -> PyResult<()> {
 /// Initialize the runtime module and expose Python functions
 pub fn register_python_bindings(runtime_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     let sleep_indefinitely_fn =
-        wrap_pyfunction_bound!(sleep_indefinitely_for_unit_tests, runtime_mod.py())?;
+        wrap_pyfunction!(sleep_indefinitely_for_unit_tests, runtime_mod.py())?;
     sleep_indefinitely_fn.setattr(
         "__module__",
         "monarch._rust_bindings.monarch_hyperactor.runtime",

--- a/monarch_hyperactor/src/shape.rs
+++ b/monarch_hyperactor/src/shape.rs
@@ -54,7 +54,7 @@ impl PyShape {
         self.inner
             .coordinates(rank)
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))
-            .and_then(|x| PyDict::from_sequence_bound(x.to_object(py).bind(py)))
+            .and_then(|x| PyDict::from_sequence(x.to_object(py).bind(py)))
     }
 
     #[pyo3(signature = (**kwargs))]
@@ -92,7 +92,7 @@ impl PyShape {
     ) -> PyResult<(Bound<'py, PyAny>, (Bound<'py, PyBytes>,))> {
         let bytes = bincode::serialize(&slf.borrow().inner)
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
-        let py_bytes = PyBytes::new_bound(slf.py(), &bytes);
+        let py_bytes = PyBytes::new(slf.py(), &bytes);
         Ok((slf.getattr("from_bytes")?, (py_bytes,)))
     }
 

--- a/monarch_messages/Cargo.toml
+++ b/monarch_messages/Cargo.toml
@@ -14,7 +14,7 @@ enum-as-inner = "0.6.0"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
-pyo3 = { version = "0.22.6", features = ["anyhow"] }
+pyo3 = { version = "0.24", features = ["anyhow"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 thiserror = "2.0.12"

--- a/monarch_messages/src/worker.rs
+++ b/monarch_messages/src/worker.rs
@@ -307,12 +307,16 @@ pub enum ResolvableFunction {
     FunctionPath(FunctionPath),
 }
 
-impl IntoPy<PyObject> for ResolvableFunction {
-    fn into_py(self, py: Python<'_>) -> PyObject {
-        match self {
-            Self::Cloudpickle(func) => func.into_py(py),
-            Self::FunctionPath(func) => func.into_py(py),
-        }
+impl<'py> IntoPyObject<'py> for ResolvableFunction {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Ok(match self {
+            Self::Cloudpickle(func) => func.into_pyobject(py)?.into_any(),
+            Self::FunctionPath(func) => func.into_pyobject(py)?.into_any(),
+        })
     }
 }
 

--- a/monarch_messages/src/worker.rs
+++ b/monarch_messages/src/worker.rs
@@ -161,14 +161,14 @@ impl Ref {
         Ok(self.id)
     }
 
-    fn __getnewargs_ex__<'py>(&self, py: Python<'py>) -> Bound<'py, PyTuple> {
-        let kwargs = PyDict::new_bound(py);
+    fn __getnewargs_ex__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
+        let kwargs = PyDict::new(py);
         kwargs.set_item("id", self.id).unwrap();
 
-        PyTuple::new_bound(
+        PyTuple::new(
             py,
             vec![
-                PyTuple::empty_bound(py).unbind().into_any(),
+                PyTuple::empty(py).unbind().into_any(),
                 kwargs.unbind().into_any(),
             ],
         )
@@ -242,7 +242,7 @@ impl FunctionPath {
                 self.path
             )
         })?;
-        let module = PyModule::import_bound(py, module_fqn)?;
+        let module = PyModule::import(py, module_fqn)?;
         let mut function = module.getattr(function_name)?;
         if function.hasattr("_remote_impl")? {
             function = function.getattr("_remote_impl")?;
@@ -283,9 +283,9 @@ impl Cloudpickle {
     }
 
     pub fn resolve<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let module = PyModule::import_bound(py, "cloudpickle")?;
+        let module = PyModule::import(py, "cloudpickle")?;
         let loads = module.getattr("loads")?;
-        loads.call1((PyBytes::new_bound(py, &self.bytes),))
+        loads.call1((PyBytes::new(py, &self.bytes),))
     }
 }
 
@@ -447,8 +447,8 @@ impl Factory {
     }
 
     #[getter]
-    fn size<'a>(&self, py: Python<'a>) -> Bound<'a, PyTuple> {
-        PyTuple::new_bound(py, self.size.iter())
+    fn size<'a>(&self, py: Python<'a>) -> PyResult<Bound<'a, PyTuple>> {
+        PyTuple::new(py, self.size.iter())
     }
 
     #[getter]

--- a/monarch_meta_extension/Cargo.toml
+++ b/monarch_meta_extension/Cargo.toml
@@ -19,6 +19,6 @@ fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rus
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_extension = { version = "0.0.0", path = "../hyperactor_extension" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
-pyo3 = { version = "0.22.6", features = ["anyhow"] }
-pyo3-async-runtimes = { git = "https://github.com/PyO3/pyo3-async-runtimes", rev = "f6bb9b471a5b7765dd770af36e83f26802459621", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.24", features = ["anyhow"] }
+pyo3-async-runtimes = { git = "https://github.com/PyO3/pyo3-async-runtimes", rev = "c5a3746f110b4d246556b0f6c29f5f555919eee3", features = ["attributes", "tokio-runtime"] }
 tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }

--- a/monarch_tensor_worker/Cargo.toml
+++ b/monarch_tensor_worker/Cargo.toml
@@ -25,7 +25,7 @@ monarch_types = { version = "0.0.0", path = "../monarch_types" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 nix = { version = "0.29.0", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
-pyo3 = { version = "0.22.6", features = ["anyhow"] }
+pyo3 = { version = "0.24", features = ["anyhow"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["float_roundtrip", "unbounded_depth"] }
 sorted-vec = "0.8.3"

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -1537,27 +1537,24 @@ mod tests {
             .unwrap();
         let (split_arg, sort_list, mesh_ref, dim, layout, none, scalar, device, memory_format) =
             Python::with_gil(|py| {
-                let split_arg: PickledPyObject = PyString::new_bound(py, "/fbs/fbc/foo/bar")
+                let split_arg: PickledPyObject = PyString::new(py, "/fbs/fbc/foo/bar")
                     .into_any()
                     .try_into()?;
-                let sort_list: PickledPyObject = PyList::new_bound(py, [65, 34, 79, 1, 5])
-                    .into_any()
-                    .try_into()?;
+                let sort_list: PickledPyObject =
+                    PyList::new(py, [65, 34, 79, 1, 5])?.into_any().try_into()?;
                 let mesh_ref: PickledPyObject =
                     Ref { id: 5 }.into_py(py).into_bound(py).try_into()?;
-                let dim: PickledPyObject = PyString::new_bound(py, "x").into_any().try_into()?;
-                let layout: PickledPyObject =
-                    py.import_bound("torch")?.getattr("strided")?.try_into()?;
+                let dim: PickledPyObject = PyString::new(py, "x").into_any().try_into()?;
+                let layout: PickledPyObject = py.import("torch")?.getattr("strided")?.try_into()?;
                 let none: PickledPyObject = py.None().into_any().into_bound(py).try_into()?;
-                let scalar: PickledPyObject =
-                    py.import_bound("torch")?.getattr("float32")?.try_into()?;
+                let scalar: PickledPyObject = py.import("torch")?.getattr("float32")?.try_into()?;
                 let device: PickledPyObject = py
-                    .import_bound("torch")?
+                    .import("torch")?
                     .getattr("device")?
                     .call1(("cuda:1",))?
                     .try_into()?;
                 let memory_format: PickledPyObject = py
-                    .import_bound("torch")?
+                    .import("torch")?
                     .getattr("contiguous_format")?
                     .try_into()?;
                 PyResult::Ok((
@@ -2225,7 +2222,7 @@ mod tests {
             PickledPyObject,
         ) = Python::with_gil(|py| {
             PyResult::Ok((
-                PyList::new_bound(py, [2, 3]).into_any().try_into()?,
+                PyList::new(py, [2, 3])?.into_any().try_into()?,
                 Ref { id: 2 }.into_py(py).into_bound(py).try_into()?,
                 Ref { id: 4 }.into_py(py).into_bound(py).try_into()?,
             ))

--- a/monarch_tensor_worker/src/py_pipe.rs
+++ b/monarch_tensor_worker/src/py_pipe.rs
@@ -21,7 +21,7 @@ use crate::pipe::Pipe;
 /// Wrapper around `Pipe` to make it usable in Python.
 #[pyclass]
 pub struct PyPipe {
-    pipe: Box<dyn Pipe<PyTree<RValue>> + Send>,
+    pipe: Box<dyn Pipe<PyTree<RValue>> + Send + Sync>,
     #[pyo3(get)]
     ranks: HashMap<String, usize>,
     #[pyo3(get)]
@@ -31,7 +31,7 @@ pub struct PyPipe {
 
 impl PyPipe {
     pub fn new(
-        pipe: Box<dyn Pipe<PyTree<RValue>> + Send>,
+        pipe: Box<dyn Pipe<PyTree<RValue>> + Send + Sync>,
         ranks: HashMap<String, usize>,
         sizes: HashMap<String, usize>,
         allow_unsafe_obj_conversion: bool,

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -1446,8 +1446,7 @@ impl StreamMessageHandler for StreamActor {
                                                 rvalue.try_to_object_unsafe(py)
                                             })
                                             .collect::<Result<Vec<_>, _>>()?;
-                                        PyTuple::new_bound(py, &py_rvalues)
-                                            .extract::<PyTree<RValue>>()
+                                        PyTuple::new(py, &py_rvalues)?.extract::<PyTree<RValue>>()
                                     })()
                                     .map_err(SerializablePyErr::from_fn(py))?)
                                 })

--- a/monarch_tensor_worker/src/test_util.rs
+++ b/monarch_tensor_worker/src/test_util.rs
@@ -10,6 +10,7 @@ use std::io::IsTerminal;
 
 use anyhow::Result;
 use pyo3::Python;
+use pyo3::ffi::c_str;
 use tracing_subscriber::fmt::format::FmtSpan;
 
 pub fn test_setup() -> Result<()> {
@@ -48,7 +49,7 @@ pub fn test_setup() -> Result<()> {
 
     // We need to load torch to initialize some internal structures used by
     // the FFI funcs we use to convert ivalues to/from py objects.
-    Python::with_gil(|py| py.run_bound("import torch", None, None))?;
+    Python::with_gil(|py| py.run(c_str!("import torch"), None, None))?;
 
     Ok(())
 }

--- a/monarch_types/Cargo.toml
+++ b/monarch_types/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 [dependencies]
 derive_more = { version = "1.0.0", features = ["full"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
-pyo3 = { version = "0.22.6", features = ["anyhow"] }
+pyo3 = { version = "0.24", features = ["anyhow"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 

--- a/monarch_types/src/pyobject.rs
+++ b/monarch_types/src/pyobject.rs
@@ -21,7 +21,7 @@ impl PickledPyObject {
     pub fn pickle<'py>(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
         let bytes = obj
             .py()
-            .import_bound("pickle")?
+            .import("pickle")?
             .call_method1("dumps", (obj,))?
             .downcast_into::<PyBytes>()?
             .as_bytes()
@@ -30,7 +30,7 @@ impl PickledPyObject {
     }
 
     pub fn unpickle<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        py.import_bound("pickle")?
+        py.import("pickle")?
             .call_method1("loads", (self.0.as_slice(),))
     }
 }

--- a/torch-sys/Cargo.toml
+++ b/torch-sys/Cargo.toml
@@ -17,7 +17,7 @@ derive_more = { version = "1.0.0", features = ["full"] }
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
 nccl-sys = { path = "../nccl-sys", optional = true }
 paste = "1.0.14"
-pyo3 = { version = "0.22.6", features = ["anyhow"] }
+pyo3 = { version = "0.24", features = ["anyhow"] }
 regex = "1.11.1"
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 thiserror = "2.0.12"

--- a/torch-sys/src/backend.rs
+++ b/torch-sys/src/backend.rs
@@ -284,7 +284,7 @@ impl BoxedBackend {
 
 fn register(py: Python<'_>) -> PyResult<()> {
     // Import torch.distributed module
-    let module = py.import_bound("torch.distributed")?;
+    let module = py.import("torch.distributed")?;
 
     // Get the register_backend attribute from Backend
     let backend = module.getattr("Backend")?;
@@ -295,7 +295,7 @@ fn register(py: Python<'_>) -> PyResult<()> {
 
     // We use the extended API so that callers can pass in the inner, pre-
     // initialized backend via `pg_options`.
-    let kwargs = PyDict::new_bound(py);
+    let kwargs = PyDict::new(py);
     kwargs.set_item("devices", vec!["cuda"])?;
     kwargs.set_item("extended_api", true)?;
 
@@ -308,7 +308,7 @@ fn register(py: Python<'_>) -> PyResult<()> {
 }
 
 fn init_process_group(py: Python<'_>, world_size: usize, rank: usize) -> PyResult<()> {
-    let torchd = py.import_bound("torch.distributed")?;
+    let torchd = py.import("torch.distributed")?;
 
     // Get the register_backend attribute from Backend
     let backend = torchd.getattr("Backend")?;
@@ -319,7 +319,7 @@ fn init_process_group(py: Python<'_>, world_size: usize, rank: usize) -> PyResul
 
     // We use the extended API so that callers can pass in the inner, pre-
     // initialized backend via `pg_options`.
-    let kwargs = PyDict::new_bound(py);
+    let kwargs = PyDict::new(py);
     kwargs.set_item("extended_api", true)?;
 
     // Register the backend
@@ -328,7 +328,7 @@ fn init_process_group(py: Python<'_>, world_size: usize, rank: usize) -> PyResul
         .inspect_err(|e| tracing::error!("failed init backend: {}", e))?;
 
     // Init the process group.
-    let kwargs = PyDict::new_bound(py);
+    let kwargs = PyDict::new(py);
     // Use a special noop backend that errors out if it's actually used.
     kwargs.set_item("backend", "null")?;
     kwargs.set_item("rank", rank)?;
@@ -360,7 +360,7 @@ pub fn new_group<'py, B: Backend<Error = anyhow::Error>>(
     // Make sure we've registered the monarch backend.
     py.allow_threads(|| REGISTER.get_or_try_init(|| Python::with_gil(register)))?;
 
-    let kwargs = PyDict::new_bound(py);
+    let kwargs = PyDict::new(py);
     kwargs.set_item("backend", "monarch")?;
     kwargs.set_item("ranks", ranks)?;
     kwargs.set_item(
@@ -368,7 +368,7 @@ pub fn new_group<'py, B: Backend<Error = anyhow::Error>>(
         Box::into_raw(Box::new(BoxedBackend(Box::new(backend)))) as u64,
     )?;
 
-    let torchd = py.import_bound("torch.distributed")?;
+    let torchd = py.import("torch.distributed")?;
 
     torchd.call_method("new_group", (), Some(&kwargs))
 }

--- a/torch-sys/src/device.rs
+++ b/torch-sys/src/device.rs
@@ -401,7 +401,7 @@ mod tests {
         let expected: DeviceType = DeviceType::CUDA;
         let actual = Python::with_gil(|py| {
             // import torch to ensure torch.dtype types are registered
-            py.import_bound("torch")?;
+            py.import("torch")?;
             let obj = expected.clone().into_py(py);
             obj.extract::<DeviceType>(py)
         })?;
@@ -415,7 +415,7 @@ mod tests {
         let expected: DeviceIndex = 3.into();
         let actual = Python::with_gil(|py| {
             // import torch to ensure torch.dtype types are registered
-            py.import_bound("torch")?;
+            py.import("torch")?;
             let obj = expected.clone().into_py(py);
             obj.extract::<DeviceIndex>(py)
         })?;
@@ -429,7 +429,7 @@ mod tests {
         let expected: Device = "cuda:2".try_into()?;
         let actual = Python::with_gil(|py| {
             // import torch to ensure torch.dtype types are registered
-            py.import_bound("torch")?;
+            py.import("torch")?;
             let obj = expected.clone().into_py(py);
             obj.extract::<Device>(py)
         })?;
@@ -442,10 +442,7 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         let expected: Device = "cuda:2".try_into()?;
         let actual = Python::with_gil(|py| {
-            let obj = py
-                .import_bound("torch")?
-                .getattr("device")?
-                .call1(("cuda:2",))?;
+            let obj = py.import("torch")?.getattr("device")?.call1(("cuda:2",))?;
             obj.extract::<Device>()
         })?;
         assert_eq!(actual, expected);

--- a/torch-sys/src/ivalue.rs
+++ b/torch-sys/src/ivalue.rs
@@ -459,9 +459,9 @@ mod tests {
         let args_info =
             crate::call_op::get_schema_args_info("aten::_foreach_add_", "Tensor").unwrap();
         let (list, tensor, tensor_1, tensor_1_err) = Python::with_gil(|py| {
-            let list = pyo3::types::PyList::empty_bound(py).into_any();
+            let list = pyo3::types::PyList::empty(py).into_any();
             let none = py.None().into_bound(py);
-            let one = PyFloat::new_bound(py, 1.0).into_any();
+            let one = PyFloat::new(py, 1.0).into_any();
             (
                 IValue::from_py_object_with_type(
                     list,
@@ -508,7 +508,7 @@ mod tests {
                             // We need to load torch to initialize some internal
                             // structures used by the FFI funcs we use to convert
                             // ivalues to/from py objects.
-                            Python::with_gil(|py| py.run_bound("import torch", None, None)).unwrap();
+                            Python::with_gil(|py| py.run(pyo3::ffi::c_str!("import torch"), None, None)).unwrap();
                             let original = IValue::from($input);
                             // SAFETY: `TryIntoPyObject` consumes the value, so
                             // we clone here to use for the `assert_eq` at end.
@@ -557,7 +557,7 @@ mod tests {
                             // We need to load torch to initialize some internal
                             // structures used by the FFI funcs we use to convert
                             // ivalues to/from py objects.
-                            Python::with_gil(|py| py.run_bound("import torch", None, None)).unwrap();
+                            Python::with_gil(|py| py.run(pyo3::ffi::c_str!("import torch"), None, None)).unwrap();
                             let original = IValue::from($input);
                             let converted: IValue = bincode::deserialize(&bincode::serialize(&original).unwrap()).unwrap();
                             assert!(ivalues_equal_with_tensor_equal(original, converted));

--- a/torch-sys/src/layout.rs
+++ b/torch-sys/src/layout.rs
@@ -65,7 +65,7 @@ mod tests {
         let layout = Layout::Strided;
         let converted_type = Python::with_gil(|py| {
             // import torch to ensure torch.layout types are registered
-            py.import_bound("torch").unwrap();
+            py.import("torch").unwrap();
             let obj = layout.into_py(py);
             obj.extract::<Layout>(py).unwrap()
         });
@@ -76,11 +76,7 @@ mod tests {
     fn from_py() {
         pyo3::prepare_freethreaded_python();
         let layout = Python::with_gil(|py| {
-            let obj = py
-                .import_bound("torch")
-                .unwrap()
-                .getattr("strided")
-                .unwrap();
+            let obj = py.import("torch").unwrap().getattr("strided").unwrap();
             obj.extract::<Layout>().unwrap()
         });
         assert_eq!(layout, Layout::Strided);

--- a/torch-sys/src/memory_format.rs
+++ b/torch-sys/src/memory_format.rs
@@ -64,7 +64,7 @@ mod tests {
         let memory_format = MemoryFormat::Contiguous;
         let converted_type = Python::with_gil(|py| {
             // import torch to ensure torch.layout types are registered
-            py.import_bound("torch").unwrap();
+            py.import("torch").unwrap();
             let obj = memory_format.into_py(py);
             obj.extract::<MemoryFormat>(py).unwrap()
         });
@@ -76,7 +76,7 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         let memory_format = Python::with_gil(|py| {
             let obj = py
-                .import_bound("torch")
+                .import("torch")
                 .unwrap()
                 .getattr("preserve_format")
                 .unwrap();

--- a/torch-sys/src/rvalue.rs
+++ b/torch-sys/src/rvalue.rs
@@ -136,7 +136,7 @@ impl TryIntoPyObject<PyAny> for &RValue {
             RValue::Layout(val) => Ok(val.clone().into_py(py).into_bound(py)),
             RValue::ScalarType(val) => Ok(val.clone().into_py(py).into_bound(py)),
             RValue::MemoryFormat(val) => Ok(val.clone().into_py(py).into_bound(py)),
-            RValue::None => Ok(PyNone::get_bound(py).to_owned().into_any()),
+            RValue::None => Ok(PyNone::get(py).to_owned().into_any()),
             RValue::PyObject(val) => val.unpickle(py),
             _ => Err(PyErr::new::<PyValueError, _>(format!(
                 "cannot safely create py object from {:?}",
@@ -156,7 +156,7 @@ impl TryIntoPyObjectUnsafe<PyAny> for &RValue {
             RValue::Layout(val) => Ok(val.clone().into_py(py).into_bound(py)),
             RValue::ScalarType(val) => Ok(val.clone().into_py(py).into_bound(py)),
             RValue::MemoryFormat(val) => Ok(val.clone().into_py(py).into_bound(py)),
-            RValue::None => Ok(PyNone::get_bound(py).to_owned().into_any()),
+            RValue::None => Ok(PyNone::get(py).to_owned().into_any()),
             RValue::PyObject(val) => val.unpickle(py),
             // SAFETY: This inherits the unsafety of `rvalue_to_ivalue` (see comment
             // above).
@@ -189,6 +189,7 @@ mod tests {
     use std::assert_matches::assert_matches;
 
     use anyhow::Result;
+    use pyo3::ffi::c_str;
     use pyo3::prelude::*;
 
     use super::*;
@@ -198,10 +199,10 @@ mod tests {
         pyo3::prepare_freethreaded_python();
         let rval = Python::with_gil(|py| {
             // Needed to initialize torch.
-            py.import_bound("torch")?;
+            py.import("torch")?;
 
             // Define the Custom class inline
-            py.run_bound("class Custom:\n    pass", None, None)?;
+            py.run(c_str!("class Custom:\n    pass"), None, None)?;
 
             let obj = py.eval_bound("Custom()", None, None)?;
             RValue::extract_bound(&obj)

--- a/torch-sys/src/scalar_type.rs
+++ b/torch-sys/src/scalar_type.rs
@@ -64,7 +64,7 @@ mod tests {
         let scalar_type = ScalarType::Float;
         let converted_type = Python::with_gil(|py| {
             // import torch to ensure torch.dtype types are registered
-            py.import_bound("torch").unwrap();
+            py.import("torch").unwrap();
             let obj = scalar_type.into_py(py);
             obj.extract::<ScalarType>(py).unwrap()
         });
@@ -75,11 +75,7 @@ mod tests {
     fn from_py() {
         pyo3::prepare_freethreaded_python();
         let scalar_type = Python::with_gil(|py| {
-            let obj = py
-                .import_bound("torch")
-                .unwrap()
-                .getattr("float32")
-                .unwrap();
+            let obj = py.import("torch").unwrap().getattr("float32").unwrap();
             obj.extract::<ScalarType>().unwrap()
         });
         assert_eq!(scalar_type, ScalarType::Float);

--- a/torch-sys/src/tensor.rs
+++ b/torch-sys/src/tensor.rs
@@ -246,7 +246,7 @@ mod tests {
         let tensor = test_make_tensor();
         let converted = Python::with_gil(|py| {
             // import torch to ensure torch.layout types are registered
-            py.import_bound("torch").unwrap();
+            py.import("torch").unwrap();
             let obj = deep_clone(&tensor).into_py(py);
             obj.extract::<Tensor>(py).unwrap()
         });


### PR DESCRIPTION
Summary: Fix most deprecation warnings introduced by `pyo3 = 0.24.2`

Reviewed By: dtolnay

Differential Revision: D76439928
