### PR TITLE
Expose simulator sleep to python

### DIFF
--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -29,6 +29,7 @@ monarch_types = { version = "0.0.0", path = "../monarch_types" }
 nccl-sys = { path = "../nccl-sys", optional = true }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 pyo3 = { version = "0.24", features = ["anyhow"] }
+pyo3-async-runtimes = { git = "https://github.com/PyO3/pyo3-async-runtimes", rev = "c5a3746f110b4d246556b0f6c29f5f555919eee3", features = ["attributes", "tokio-runtime"] }
 tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }
 torch-sys = { version = "0.0.0", path = "../torch-sys", optional = true }
 torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda", optional = true }

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -18,6 +18,7 @@ pub mod convert;
 mod debugger;
 #[cfg(feature = "tensor_engine")]
 mod mesh_controller;
+mod simulation_tools;
 mod simulator_client;
 #[cfg(feature = "tensor_engine")]
 mod tensor_worker;
@@ -117,7 +118,10 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
             "monarch_extension.mesh_controller",
         )?)?;
     }
-
+    simulation_tools::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_extension.simulation_tools",
+    )?)?;
     monarch_hyperactor::bootstrap::register_python_bindings(&get_or_add_new_module(
         module,
         "monarch_hyperactor.bootstrap",

--- a/monarch_extension/src/simulation_tools.rs
+++ b/monarch_extension/src/simulation_tools.rs
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use hyperactor::channel::ChannelAddr;
+use hyperactor::channel::ChannelTransport;
+use hyperactor::clock::Clock;
+use hyperactor::clock::SimClock;
+use hyperactor::simnet;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+#[pyfunction]
+#[pyo3(name = "start_event_loop")]
+pub fn start_simnet_event_loop(py: Python) -> PyResult<Bound<'_, PyAny>> {
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        simnet::start(
+            ChannelAddr::any(ChannelTransport::Unix),
+            ChannelAddr::any(ChannelTransport::Unix),
+            1000,
+        )
+        .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
+        Ok(())
+    })
+}
+
+#[pyfunction]
+#[pyo3(name="sleep",signature=(seconds))]
+pub fn py_sim_sleep<'py>(py: Python<'py>, seconds: f64) -> PyResult<Bound<'py, PyAny>> {
+    let millis = (seconds * 1000.0).ceil() as u64;
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        let duration = tokio::time::Duration::from_millis(millis);
+        SimClock.sleep(duration).await;
+        Ok(())
+    })
+}
+
+pub(crate) fn register_python_bindings(simulation_tools_mod: &Bound<'_, PyModule>) -> PyResult<()> {
+    {
+        let f = wrap_pyfunction!(py_sim_sleep, simulation_tools_mod)?;
+        f.setattr(
+            "__module__",
+            "monarch._rust_bindings.monarch_extension.simulation_tools",
+        )?;
+        simulation_tools_mod.add_function(f)?;
+    }
+    {
+        let f = wrap_pyfunction!(start_simnet_event_loop, simulation_tools_mod)?;
+        f.setattr(
+            "__module__",
+            "monarch._rust_bindings.monarch_extension.simulation_tools",
+        )?;
+        simulation_tools_mod.add_function(f)?;
+    }
+    Ok(())
+}

--- a/python/monarch/_rust_bindings/monarch_extension/simulation_tools.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/simulation_tools.pyi
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+async def sleep(seconds: float) -> None:
+    """
+    Asyncio friendly sleep that waits for the simulator event loop to wake up
+    """
+    ...
+
+async def start_event_loop() -> None:
+    """
+    Starts the simulator event loop
+    """
+    ...


### PR DESCRIPTION
Summary:
We expose the SleepEvent from the hyperactor runtime simulator into python. It is non-blocking. It can be used in Python actors to simulate latency. Once it starts, it will not allow code execution to progress until the DES event loop has advanced to the time the sleep is completed and sends a signal to wake it up.

Explanation for changes in simnet.rs:
- We re-introduce a debounce period where we do not advance to the next time with events. This was originally introduced to speed up the tensor engine use case which was deprioritized. By having a debounce, we will prevent the event loop from over advancing
- We set the default training_script_state to TrainingScriptState::Waiting in order to allow for run-ahead. For the tensor engine use case, we wanted to never advance past the wall time of when client messages came in, until we hit a fetch_shard().result() in which case it was safe to advance past wall time.

Differential Revision: D76765388
