### PR TITLE
Include command information for process spawn errors

### DIFF
--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -321,7 +321,7 @@ impl ProcessAlloc {
         match cmd.spawn() {
             Err(err) => {
                 // Likely retry won't help here so fail permanently.
-                let message = format!("spawn {}: {}", index, err);
+                let message = format!("spawn index: {}, command: {:?}: {}", index, cmd, err);
                 tracing::error!(message);
                 self.failed = true;
                 Some(ProcState::Failed {


### PR DESCRIPTION
Summary: In order to facilitate debugging, include full command information in the error message of spawn. This at least will provide clear indication of which executable it attempted to run with all of its argments.

Reviewed By: mariusae, ahmadsharif1, vidhyav

Differential Revision: D76853418
