### PR TITLE
Add initial rsync-based code syncing from proc mesh

### DIFF
--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -25,6 +25,7 @@ mockall = "0.13.1"
 ndslice = { version = "0.0.0", path = "../ndslice" }
 rand = { version = "0.8", features = ["small_rng"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
+serde_bytes = "0.11"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.17", features = ["fs", "io-util", "net", "signal", "sync", "time"] }

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -23,9 +23,11 @@ hyperactor_mesh_macros = { version = "0.0.0", path = "../hyperactor_mesh_macros"
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 mockall = "0.13.1"
 ndslice = { version = "0.0.0", path = "../ndslice" }
+nix = { version = "0.29.0", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
 rand = { version = "0.8", features = ["small_rng"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_bytes = "0.11"
+tempfile = "3.15"
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.17", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
@@ -34,6 +36,7 @@ tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]
 buck-resources = "1"
+dir-diff = "0.3"
 maplit = "1.0"
 timed_test = { version = "0.0.0", path = "../timed_test" }
 tracing-test = { version = "0.2.3", features = ["no-env-filter"] }

--- a/hyperactor_mesh/src/code_sync/mod.rs
+++ b/hyperactor_mesh/src/code_sync/mod.rs
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+pub mod rsync;

--- a/hyperactor_mesh/src/code_sync/rsync.rs
+++ b/hyperactor_mesh/src/code_sync/rsync.rs
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::io::ErrorKind;
+use std::net::SocketAddr;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use anyhow::ensure;
+use async_trait::async_trait;
+use futures::try_join;
+use hyperactor::Actor;
+use hyperactor::Handler;
+use hyperactor::Instance;
+use hyperactor::Named;
+use hyperactor::clock::Clock;
+use hyperactor::clock::RealClock;
+use hyperactor::message::IndexedErasedUnbound;
+use nix::sys::signal;
+use nix::sys::signal::Signal;
+use nix::unistd::Pid;
+use serde::Deserialize;
+use serde::Serialize;
+use tempfile::TempDir;
+use tokio::fs;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+use tokio::process::Child;
+use tokio::process::Command;
+
+use crate::actor_mesh::ActorMesh;
+use crate::actor_mesh::Cast;
+use crate::connect::Connect;
+use crate::connect::accept;
+use crate::connect::connect_mesh;
+
+pub async fn do_rsync(addr: &SocketAddr, workspace: &Path) -> Result<()> {
+    let output = Command::new("rsync")
+        .arg("--quiet")
+        .arg("--archive")
+        .arg("--delete")
+        // By setting these flags, we make `rsync` immune to multiple invocations
+        // targeting the same dir, which can happen if we don't take care to only
+        // allow one worker on a given host to do the `rsync`.
+        .arg("--delete-after")
+        .arg("--delay-updates")
+        .arg("--exclude=.rsync-tmp.*")
+        .arg(format!("--partial-dir=.rsync-tmp.{}", addr.port()))
+        .arg(format!("{}/", workspace.display()))
+        .arg(format!("rsync://{}/workspace", addr))
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+    output
+        .status
+        .exit_ok()
+        .with_context(|| format!("rsync failed: {}", String::from_utf8_lossy(&output.stderr)))?;
+    Ok(())
+}
+
+#[derive(Debug)]
+pub struct RsyncDaemon {
+    child: Child,
+    #[allow(unused)]
+    state: TempDir,
+    addr: SocketAddr,
+}
+
+impl RsyncDaemon {
+    pub async fn spawn(listener: TcpListener, workspace: &Path) -> Result<Self> {
+        let state = TempDir::with_prefix("rsyncd.")?;
+
+        // Write rsync config file
+        // TODO(agallagher): We can setup a secrets file to provide some measure of
+        // security and prevent stray rsync calls from hitting the server.
+        let content = format!(
+            r#"\
+[workspace]
+    path = {workspace}
+    use chroot = no
+    list = no
+    read only = false
+    write only = true
+    uid = {uid}
+    hosts allow = localhost
+"#,
+            workspace = workspace.display(),
+            uid = nix::unistd::getuid().as_raw(),
+        );
+        let config = state.path().join("rsync.config");
+        fs::write(&config, content).await?;
+
+        // Find free port.  This is potentially racy, as some process could
+        // potentially bind to this port in between now and when `rsync` starts up
+        // below.  But I'm not sure a better way to do this, as rsync doesn't appear
+        // to support `rsync --sockopts=SO_PORTREUSE` (to share this port we've
+        // reserved) or `--port=0` (to pick a free port -- it'll just always use
+        // 873).
+        let addr = listener.local_addr()?;
+        std::mem::drop(listener);
+
+        // Spawn the rsync daemon.
+        let mut child = Command::new("rsync")
+            .arg("--daemon")
+            .arg("--no-detach")
+            .arg(format!("--address={}", addr.ip()))
+            .arg(format!("--port={}", addr.port()))
+            .arg(format!("--config={}", config.display()))
+            //.arg(format!("--log-file={}/log", state.path().display()))
+            .arg("--log-file=/dev/stderr")
+            .kill_on_drop(true)
+            .spawn()?;
+
+        // Wait until the rsync daemon is ready to connect via polling it (I tried polling
+        // the log file to wait for the "listening" log line, but that gets prevented *before*
+        // it actually starts the listening loop).
+        tokio::select! {
+            res = child.wait() => bail!("unexpected early exit: {:?}", res),
+            res = async {
+                loop {
+                    match TcpStream::connect(addr).await {
+                        Err(err) if err.kind() == ErrorKind::ConnectionRefused => {
+                            RealClock.sleep(Duration::from_millis(1)).await
+                        }
+                        Err(err) => return Err(err.into()),
+                        Ok(_) => break,
+                    }
+                }
+                anyhow::Ok(())
+            } => res?,
+        }
+
+        Ok(Self { child, state, addr })
+    }
+
+    pub fn addr(&self) -> &SocketAddr {
+        &self.addr
+    }
+
+    pub async fn shutdown(mut self) -> Result<()> {
+        let id = self.child.id().context("missing pid")?;
+        let pid = Pid::from_raw(id as i32);
+        signal::kill(pid, Signal::SIGINT)?;
+        let status = self.child.wait().await?;
+        // rsync exists with 20 when sent SIGINT.
+        ensure!(status.code() == Some(20));
+        Ok(())
+    }
+}
+
+#[derive(Debug, Named, Serialize, Deserialize)]
+pub struct RsyncParams {}
+
+#[derive(Debug)]
+#[hyperactor::export(
+    spawn = true,
+    handlers = [
+        Connect,
+        Cast<Connect>,
+        IndexedErasedUnbound<Cast<Connect>>,
+    ],
+)]
+pub struct RsyncActor {
+    daemon: RsyncDaemon,
+}
+
+#[async_trait]
+impl Actor for RsyncActor {
+    type Params = RsyncParams;
+
+    async fn new(RsyncParams {}: Self::Params) -> Result<Self> {
+        let daemon = RsyncDaemon::spawn(
+            TcpListener::bind(("::1", 0)).await?,
+            &PathBuf::from(std::env::var("WORKSPACE_DIR")?),
+        )
+        .await?;
+        Ok(Self { daemon })
+    }
+}
+
+#[async_trait]
+impl Handler<Connect> for RsyncActor {
+    async fn handle(
+        &mut self,
+        this: &Instance<Self>,
+        message: Connect,
+    ) -> Result<(), anyhow::Error> {
+        let (mut local, mut stream) = try_join!(
+            async { Ok(TcpStream::connect(self.daemon.addr()).await?) },
+            async {
+                let (rd, wr) = accept(this, message).await?;
+                anyhow::Ok(tokio::io::join(rd, wr))
+            }
+        )?;
+        tokio::io::copy_bidirectional(&mut local, &mut stream).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<Cast<Connect>> for RsyncActor {
+    async fn handle(
+        &mut self,
+        this: &Instance<Self>,
+        message: Cast<Connect>,
+    ) -> anyhow::Result<()> {
+        <Self as Handler<Connect>>::handle(self, this, message.message).await
+    }
+}
+
+pub async fn rsync_mesh<M>(actor_mesh: M, workspace: PathBuf) -> Result<()>
+where
+    M: ActorMesh<Actor = RsyncActor>,
+{
+    connect_mesh(actor_mesh, async move |rd, wr| {
+        let workspace = workspace.clone();
+        let listener = TcpListener::bind(("::1", 0)).await?;
+        let addr = listener.local_addr()?;
+        let mut local = tokio::io::join(rd, wr);
+        try_join!(
+            async move { do_rsync(&addr, &workspace).await },
+            async move {
+                let (mut stream, _) = listener.accept().await?;
+                tokio::io::copy_bidirectional(&mut stream, &mut local).await?;
+                anyhow::Ok(())
+            },
+        )?;
+        anyhow::Ok(())
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use anyhow::anyhow;
+    use tempfile::TempDir;
+    use tokio::fs;
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_simple() -> Result<()> {
+        let input = TempDir::new()?;
+        fs::write(input.path().join("foo.txt"), "hello world").await?;
+
+        let output = TempDir::new()?;
+
+        let server = TcpListener::bind(("::", 0)).await?;
+        let daemon = RsyncDaemon::spawn(server, output.path()).await?;
+        do_rsync(daemon.addr(), input.path()).await?;
+        daemon.shutdown().await?;
+
+        assert!(!dir_diff::is_different(&input, &output).map_err(|e| anyhow!("{:?}", e))?);
+
+        Ok(())
+    }
+}

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::io::Cursor;
+use std::pin::Pin;
+use std::time::Duration;
+
+use anyhow::Result;
+use futures::Stream;
+use futures::StreamExt;
+use futures::future;
+use futures::stream::FuturesUnordered;
+use futures::task::Context;
+use futures::task::Poll;
+use hyperactor::Mailbox;
+use hyperactor::Named;
+use hyperactor::OncePortRef;
+use hyperactor::PortRef;
+use hyperactor::RemoteHandles;
+use hyperactor::actor::RemoteActor;
+use hyperactor::cap::CanOpenPort;
+use hyperactor::cap::CanSend;
+use hyperactor::clock::Clock;
+use hyperactor::clock::RealClock;
+use hyperactor::mailbox::PortReceiver;
+use hyperactor::mailbox::open_once_port;
+use hyperactor::mailbox::open_port;
+use hyperactor::message::Bind;
+use hyperactor::message::Bindings;
+use hyperactor::message::IndexedErasedUnbound;
+use hyperactor::message::Unbind;
+use ndslice::selection::dsl;
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncWrite;
+use tokio_util::io::StreamReader;
+
+use crate::actor_mesh::ActorMesh;
+use crate::actor_mesh::Cast;
+
+// Timeout for establishing a connection, used by both client and server.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Messages sent over the "connection" to facilitate communication.
+#[derive(Debug, Serialize, Deserialize, Named, Clone)]
+enum Io {
+    // A data packet.
+    Data(#[serde(with = "serde_bytes")] Vec<u8>),
+    // Signal the end of one side of the connection.
+    Eof,
+}
+
+/// A message sent from a client to initiate a connection.
+#[derive(Debug, Serialize, Deserialize, Named, Clone)]
+pub struct Connect {
+    // The port the server can use to complete the connection.
+    port: PortRef<Accept>,
+}
+
+/// A response message sent from the server back to the client to complete setting
+/// up the connection.
+#[derive(Debug, Serialize, Deserialize, Named, Clone)]
+pub struct Accept {
+    // The port the client will use to send data over the connection to the server.
+    conn: PortRef<Io>,
+    // Channel used by the client to send a port back to the server, which it will
+    // use to send data over the connection to the client.
+    return_conn: OncePortRef<PortRef<Io>>,
+}
+
+impl Bind for Connect {
+    fn bind(&mut self, bindings: &mut Bindings) -> Result<()> {
+        self.port.bind(bindings)
+    }
+}
+
+impl Unbind for Connect {
+    fn unbind(&self, bindings: &mut Bindings) -> Result<()> {
+        self.port.unbind(bindings)
+    }
+}
+
+struct IoMsgStream {
+    port: PortReceiver<Io>,
+}
+
+impl Stream for IoMsgStream {
+    type Item = std::io::Result<Cursor<Vec<u8>>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Create a new future each time and poll it immediately
+        // This works if recv() is cancellation-safe (like tokio mpsc)
+        let future = async {
+            match self.port.recv().await {
+                Err(err) => Some(Err(std::io::Error::other(err))),
+                Ok(Io::Data(buf)) => Some(Ok(Cursor::new(buf))),
+                // Break out of stream when we see EOF.
+                Ok(Io::Eof) => None,
+            }
+        };
+        let mut future = Box::pin(future);
+        future.as_mut().poll(cx)
+    }
+}
+
+/// Wrap a `PortReceiver<IoMsg>` as a `AsyncRead`.
+pub struct IoMsgRead {
+    inner: StreamReader<IoMsgStream, Cursor<Vec<u8>>>,
+}
+
+impl IoMsgRead {
+    fn new(port: PortReceiver<Io>) -> Self {
+        Self {
+            inner: StreamReader::new(IoMsgStream { port }),
+        }
+    }
+}
+
+impl AsyncRead for IoMsgRead {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+/// Wrap a `PortRef<IoMsg>` as a `AsyncWrite`.
+pub struct IoMsgWrite<'a, C: CanSend> {
+    caps: &'a C,
+    port: PortRef<Io>,
+}
+
+impl<'a, C: CanSend> IoMsgWrite<'a, C> {
+    fn new(caps: &'a C, port: PortRef<Io>) -> Self {
+        Self { caps, port }
+    }
+}
+
+impl<'a, C: CanSend> AsyncWrite for IoMsgWrite<'a, C> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        match self.port.send(self.caps, Io::Data(buf.into())) {
+            Ok(()) => Poll::Ready(Ok(buf.len())),
+            Err(e) => Poll::Ready(Err(std::io::Error::other(e))),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        // Send EOF on shutdown.
+        match self.port.send(self.caps, Io::Eof) {
+            Ok(()) => Poll::Ready(Ok(())),
+            Err(e) => Poll::Ready(Err(std::io::Error::other(e))),
+        }
+    }
+}
+
+/// Helper used by `Handler<Connect>`s to accept a connection initiated by a `Connect` message and
+/// return `AsyncRead` and `AsyncWrite` streams that can be used to communicate with the other side.
+pub async fn accept<'a, C: CanOpenPort + CanSend>(
+    caps: &'a C,
+    message: Connect,
+) -> Result<(IoMsgRead, IoMsgWrite<'a, C>)> {
+    let (tx, rx) = open_port::<Io>(caps);
+    let (r_tx, r_rx) = open_once_port::<PortRef<Io>>(caps);
+    message.port.send(
+        caps,
+        Accept {
+            conn: tx.bind(),
+            return_conn: r_tx.bind(),
+        },
+    )?;
+    let wr = tokio::time::timeout(CONNECT_TIMEOUT, r_rx.recv()).await??;
+    Ok((IoMsgRead::new(rx), IoMsgWrite::new(caps, wr)))
+}
+
+/// Initiate a connection to a `Handler<Connect>` and return `AsyncRead` and `AsyncWrite` streams to
+/// communicate with the other side.
+pub async fn connect<C: CanOpenPort + CanSend>(
+    caps: &C,
+    port: PortRef<Connect>,
+) -> Result<(IoMsgRead, IoMsgWrite<C>)> {
+    let (tx, mut rx) = open_port::<Accept>(caps);
+    port.send(caps, Connect { port: tx.bind() })?;
+
+    let connection = tokio::time::timeout(CONNECT_TIMEOUT, rx.recv()).await??;
+    let (tx, rx) = open_port::<Io>(caps);
+    connection.return_conn.send(caps, tx.bind())?;
+
+    Ok((IoMsgRead::new(rx), IoMsgWrite::new(caps, connection.conn)))
+}
+
+/// Initiate connections to all ranks in a `ActorMesh<Handler<Connect>>` and run the provided
+/// callback on each connection.
+pub async fn connect_mesh<M, A>(
+    actor_mesh: M,
+    handle: impl AsyncFn(IoMsgRead, IoMsgWrite<Mailbox>) -> Result<()>,
+) -> Result<()>
+where
+    M: ActorMesh<Actor = A>,
+    A: RemoteActor
+        + RemoteHandles<Cast<Connect>>
+        + RemoteHandles<IndexedErasedUnbound<Cast<Connect>>>,
+{
+    let client = actor_mesh.proc_mesh().client();
+
+    // Broadcast the initiate connection message.
+    let (tx, mut rx) = client.open_port::<Accept>();
+    actor_mesh.cast(dsl::all(dsl::true_()), Connect { port: tx.bind() })?;
+
+    // Loop to process running handlers on completed connections and waiting for outstanding handlers
+    // to complete.
+    let mut pending = actor_mesh.shape().slice().len();
+    let mut running = FuturesUnordered::default();
+    let deadline = RealClock.now() + CONNECT_TIMEOUT;
+    while !running.is_empty() || pending > 0 {
+        tokio::select! {
+            // We expect all actors to connect in the given deadline.
+            res = tokio::time::timeout_at(deadline, future::pending::<()>()), if pending > 0 => res?,
+            res = rx.recv() => {
+                let connection = res?;
+                let (tx, rx) = client.open_port::<Io>();
+                connection.return_conn.send(client, tx.bind())?;
+                running.push(Box::pin(handle(IoMsgRead::new(rx), IoMsgWrite::new(client, connection.conn))));
+                pending -= 1;
+            },
+            Some(res) = running.next() => res?,
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use futures::try_join;
+    use hyperactor::Actor;
+    use hyperactor::Handler;
+    use hyperactor::Instance;
+    use hyperactor::proc::Proc;
+    use tokio::io::AsyncReadExt;
+    use tokio::io::AsyncWriteExt;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct EchoActor {}
+
+    #[async_trait]
+    impl Actor for EchoActor {
+        type Params = ();
+
+        async fn new(_params: ()) -> Result<Self, anyhow::Error> {
+            Ok(Self {})
+        }
+    }
+
+    #[async_trait]
+    impl Handler<Connect> for EchoActor {
+        async fn handle(
+            &mut self,
+            this: &Instance<Self>,
+            message: Connect,
+        ) -> Result<(), anyhow::Error> {
+            let (mut rd, mut wr) = accept(this, message).await?;
+            tokio::io::copy(&mut rd, &mut wr).await?;
+            wr.shutdown().await?;
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_simple_connection() -> Result<()> {
+        let proc = Proc::local();
+        let client = proc.attach("client")?;
+        let actor = proc.spawn::<EchoActor>("actor", ()).await?;
+        let (mut rd, mut wr) = connect(&client, actor.port().bind()).await?;
+        let send = [3u8, 4u8, 5u8, 6u8];
+        try_join!(
+            async move {
+                wr.write_all(&send).await?;
+                wr.shutdown().await?;
+                anyhow::Ok(())
+            },
+            async {
+                let mut recv = vec![];
+                rd.read_to_end(&mut recv).await?;
+                assert_eq!(&send, recv.as_slice());
+                anyhow::Ok(())
+            },
+        )?;
+        Ok(())
+    }
+}

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -9,12 +9,14 @@
 //! This crate provides hyperactor's mesh abstractions.
 
 #![feature(assert_matches)]
+#![feature(exit_status_error)]
 #![feature(impl_trait_in_bindings)]
 
 pub mod actor_mesh;
 pub mod alloc;
 mod assign;
 pub mod bootstrap;
+pub mod code_sync;
 pub mod comm;
 pub mod connect;
 pub mod mesh;

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -16,6 +16,7 @@ pub mod alloc;
 mod assign;
 pub mod bootstrap;
 pub mod comm;
+pub mod connect;
 pub mod mesh;
 pub mod mesh_selection;
 mod metrics;

--- a/monarch_extension/src/code_sync.rs
+++ b/monarch_extension/src/code_sync.rs
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use hyperactor_mesh::RootActorMesh;
+use hyperactor_mesh::SlicedActorMesh;
+use hyperactor_mesh::code_sync::rsync;
+use hyperactor_mesh::proc_mesh::SharedSpawnable;
+use hyperactor_mesh::shape::Shape;
+use monarch_hyperactor::proc_mesh::PyProcMesh;
+use monarch_hyperactor::runtime::signal_safe_block_on;
+use monarch_hyperactor::shape::PyShape;
+use pyo3::Bound;
+use pyo3::prelude::*;
+use pyo3::types::PyModule;
+
+#[pyclass(
+    frozen,
+    name = "RsyncMeshClient",
+    module = "monarch._rust_bindings.monarch_extension.code_sync"
+)]
+pub struct RsyncMeshClient {
+    actor_mesh: Arc<RootActorMesh<'static, rsync::RsyncActor>>,
+    shape: Shape,
+    workspace: PathBuf,
+}
+
+#[pymethods]
+impl RsyncMeshClient {
+    #[staticmethod]
+    #[pyo3(signature = (*, proc_mesh, shape, workspace))]
+    fn spawn_blocking(
+        py: Python,
+        proc_mesh: &PyProcMesh,
+        shape: &PyShape,
+        workspace: PathBuf,
+    ) -> PyResult<Self> {
+        let proc_mesh = Arc::clone(&proc_mesh.inner);
+        let shape = shape.get_inner().clone();
+        signal_safe_block_on(py, async move {
+            let actor_mesh = proc_mesh.spawn("rsync", &rsync::RsyncParams {}).await?;
+            Ok(Self {
+                actor_mesh: Arc::new(actor_mesh),
+                shape,
+                workspace,
+            })
+        })?
+    }
+
+    fn sync_workspace<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let workspace = self.workspace.clone();
+        let inner_mesh = self.actor_mesh.clone();
+        let shape = self.shape.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mesh = SlicedActorMesh::new(&inner_mesh, shape);
+            Ok(rsync::rsync_mesh(mesh, workspace).await?)
+        })
+    }
+}
+
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    module.add_class::<RsyncMeshClient>()?;
+    Ok(())
+}

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -10,6 +10,7 @@
 
 #[cfg(feature = "tensor_engine")]
 mod client;
+pub mod code_sync;
 #[cfg(feature = "tensor_engine")]
 mod controller;
 #[cfg(feature = "tensor_engine")]
@@ -170,6 +171,10 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_extension::telemetry::register_python_bindings(&get_or_add_new_module(
         module,
         "hyperactor_extension.telemetry",
+    )?)?;
+    code_sync::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_extension.code_sync",
     )?)?;
 
     crate::panic::register_python_bindings(&get_or_add_new_module(

--- a/monarch_hyperactor/src/shape.rs
+++ b/monarch_hyperactor/src/shape.rs
@@ -23,6 +23,13 @@ use crate::ndslice::PySlice;
 pub struct PyShape {
     pub(super) inner: Shape,
 }
+
+impl PyShape {
+    pub fn get_inner(&self) -> &Shape {
+        &self.inner
+    }
+}
+
 #[pymethods]
 impl PyShape {
     #[new]

--- a/python/monarch/_rust_bindings/monarch_extension/code_sync.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/code_sync.pyi
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import final
+
+from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
+
+from monarch._rust_bindings.monarch_hyperactor.shape import Shape
+
+@final
+class RsyncMeshClient:
+    """
+    Python binding for the Rust RsyncMeshClient.
+    """
+    @staticmethod
+    def spawn_blocking(
+        proc_mesh: ProcMesh,
+        shape: Shape,
+        workspace: str,
+    ) -> RsyncMeshClient: ...
+    async def sync_workspace(self) -> None: ...

--- a/python/monarch/code_sync.py
+++ b/python/monarch/code_sync.py
@@ -1,0 +1,9 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from monarch._rust_bindings.monarch_extension.code_sync import (  # noqa: F401
+    RsyncMeshClient,
+)


### PR DESCRIPTION
Summary:
Initial setup for supporting code-sync, using:
1) An rsync server run from client/controller,
2) Rsync actors that run on the workers, which initiate `rsync` calls to the server

These are setup in `ProcMesh` python, and exposed via a `sync_workspace()`
async call.

The abstractions haven't been completely worked out yet and will likely need
iteration as we expand use cases.

Reviewed By: mariusae

Differential Revision: D76734857


