### PR TITLE
mesh:reify shape with proc-mesh shape

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -83,6 +83,7 @@ pub trait ActorMesh: Mesh {
         // TODO: We should repair this by introducing an explicit stream key, associated
         // with the root mesh.
         let selection_of_slice = self
+            .proc_mesh()
             .shape()
             .slice()
             .reify_view(self.shape().slice())


### PR DESCRIPTION
Summary: In practice this appears not to matter, but is still technically correct.

Differential Revision: D77038660


