### PR TITLE
Fix duplicate feature gate clippy warnings

### DIFF
--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#![cfg(feature = "tensor_engine")]
-
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -98,7 +98,7 @@ impl WorkerResponse {
     fn result(&self, py: Python<'_>) -> PyResult<PyObject> {
         if let Some(result) = &self.result {
             if result.is_err() {
-                Ok(PyNone::get(py).into_py(py))
+                Ok(PyNone::get(py).as_any().clone().unbind())
             } else {
                 // TODO: Use better shared error class
                 let rvalue = result
@@ -113,15 +113,15 @@ impl WorkerResponse {
                 Ok(unsafe { rvalue.try_to_object_unsafe(py)?.unbind() })
             }
         } else {
-            Ok(PyNone::get(py).into_py(py))
+            Ok(PyNone::get(py).as_any().clone().unbind())
         }
     }
 
     fn exception(&self, py: Python<'_>) -> PyResult<PyObject> {
         match self.result.as_ref() {
-            Some(Ok(_)) => Ok(PyNone::get(py).into_py(py)),
+            Some(Ok(_)) => Ok(PyNone::get(py).as_any().clone().unbind()),
             Some(Err(exc)) => Ok(PyException::exception_to_py(py, exc)?),
-            None => Ok(PyNone::get(py).into_py(py)),
+            None => Ok(PyNone::get(py).as_any().clone().unbind()),
         }
     }
 
@@ -159,7 +159,13 @@ impl PyWorldState {
     fn procs(self_: PyRef<Self>, py: Python) -> PyResult<PyObject> {
         let proc_dict = PyDict::new(py);
         for (proc_id, proc_info) in self_.inner.procs.clone() {
-            proc_dict.set_item(proc_id.to_string(), PyProcInfo::from(proc_info).into_py(py))?;
+            proc_dict.set_item(
+                proc_id.to_string(),
+                PyProcInfo::from(proc_info)
+                    .into_pyobject(py)?
+                    .into_any()
+                    .unbind(),
+            )?;
         }
         Ok(proc_dict.into())
     }
@@ -198,14 +204,16 @@ impl PySystemSnapshotFilter {
     }
 
     #[getter]
-    fn worlds(self_: PyRef<Self>, py: Python) -> PyObject {
-        self_
+    fn worlds(self_: PyRef<Self>, py: Python) -> PyResult<PyObject> {
+        Ok(self_
             .inner
             .worlds
             .iter()
             .map(|world_id| world_id.name())
             .collect::<Vec<_>>()
-            .into_py(py)
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
     }
 
     #[getter]
@@ -269,8 +277,8 @@ impl From<WorldSnapshotProcInfo> for PyProcInfo {
 #[pymethods]
 impl PyProcInfo {
     #[getter]
-    fn labels(self_: PyRef<Self>, py: Python) -> PyObject {
-        self_.inner.labels.clone().into_py_dict_bound(py).into()
+    fn labels(self_: PyRef<Self>, py: Python) -> PyResult<PyObject> {
+        Ok(self_.inner.labels.clone().into_py_dict(py)?.into())
     }
 }
 
@@ -288,12 +296,14 @@ impl PyException {
     pub(crate) fn exception_to_py(py: Python<'_>, exc: &Exception) -> PyResult<PyObject> {
         let initializer = PyClassInitializer::from(PyException { inner: exc.clone() });
         Ok(match exc {
-            Exception::Error(_, _, _) => {
-                Py::new(py, initializer.add_subclass(PyError))?.to_object(py)
-            }
-            Exception::Failure(_) => {
-                Py::new(py, initializer.add_subclass(PyFailure))?.to_object(py)
-            }
+            Exception::Error(_, _, _) => Py::new(py, initializer.add_subclass(PyError))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind(),
+            Exception::Failure(_) => Py::new(py, initializer.add_subclass(PyFailure))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind(),
         })
     }
 }
@@ -345,7 +355,10 @@ impl PyError {
             ),
         })
         .add_subclass(Self);
-        Ok(Py::new(py, initializer)?.to_object(py))
+        Ok(Py::new(py, initializer)?
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
     }
 
     #[getter]
@@ -485,7 +498,10 @@ impl PyFailure {
             }),
         })
         .add_subclass(Self);
-        Ok(Py::new(py, initializer)?.to_object(py))
+        Ok(Py::new(py, initializer)?
+            .into_pyobject(py)?
+            .into_any()
+            .unbind())
     }
 
     #[getter]
@@ -661,13 +677,18 @@ impl ClientActor {
         Python::with_gil(|py| {
             match result {
                 Ok(Some(ClientMessage::Result { seq, result })) => {
-                    Ok(WorkerResponse { seq, result }.into_py(py))
+                    Ok(WorkerResponse { seq, result }
+                        .into_pyobject(py)?
+                        .into_any()
+                        .unbind())
                 }
                 Ok(Some(ClientMessage::Log { level, message })) => Ok(LogMessage {
                     level: PyLogLevel::from(level),
                     message,
                 }
-                .into_py(py)),
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
                 Ok(Some(ClientMessage::DebuggerMessage {
                     debugger_actor_id,
                     action,
@@ -675,8 +696,10 @@ impl ClientActor {
                     debugger_actor_id: debugger_actor_id.into(),
                     action,
                 }
-                .into_py(py)),
-                Ok(None) => Ok(PyNone::get(py).into_py(py)),
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()),
+                Ok(None) => Ok(PyNone::get(py).as_any().clone().unbind()),
                 Err(err) => {
                     if let Some(ControllerError::Failed(controller_id, err_msg)) =
                         err.downcast_ref::<ControllerError>()
@@ -690,7 +713,9 @@ impl ClientActor {
                             seq: Seq::default(),
                             result: Some(Err(Exception::Failure(failure))),
                         }
-                        .into_py(py))
+                        .into_pyobject(py)?
+                        .into_any()
+                        .unbind())
                     } else {
                         Err(PyRuntimeError::new_err(err.to_string()))
                     }
@@ -717,23 +742,32 @@ impl ClientActor {
             .drain_and_stop()
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))?
             .into_iter()
-            .map(|message| match message {
-                ClientMessage::Result { seq, result } => WorkerResponse { seq, result }.into_py(py),
-                ClientMessage::Log { level, message } => LogMessage {
-                    level: PyLogLevel::from(level),
-                    message,
-                }
-                .into_py(py),
-                ClientMessage::DebuggerMessage {
-                    debugger_actor_id,
-                    action,
-                } => DebuggerMessage {
-                    debugger_actor_id: debugger_actor_id.into(),
-                    action,
-                }
-                .into_py(py),
+            .map(|message| {
+                Ok(match message {
+                    ClientMessage::Result { seq, result } => WorkerResponse { seq, result }
+                        .into_pyobject(py)?
+                        .into_any()
+                        .unbind(),
+                    ClientMessage::Log { level, message } => LogMessage {
+                        level: PyLogLevel::from(level),
+                        message,
+                    }
+                    .into_pyobject(py)?
+                    .into_any()
+                    .unbind(),
+                    ClientMessage::DebuggerMessage {
+                        debugger_actor_id,
+                        action,
+                    } => DebuggerMessage {
+                        debugger_actor_id: debugger_actor_id.into(),
+                        action,
+                    }
+                    .into_pyobject(py)?
+                    .into_any()
+                    .unbind(),
+                })
             })
-            .collect::<Vec<PyObject>>();
+            .collect::<PyResult<Vec<PyObject>>>()?;
         PyList::new(py, messages)
     }
 
@@ -794,7 +828,10 @@ impl ClientActor {
             for (world, status) in snapshot.worlds {
                 worlds_dict.set_item(
                     world.to_string(),
-                    Py::new(py, PyWorldState { inner: status })?.to_object(py),
+                    Py::new(py, PyWorldState { inner: status })?
+                        .into_pyobject(py)?
+                        .into_any()
+                        .unbind(),
                 )?;
             }
             Ok(worlds_dict.into())

--- a/monarch_extension/src/controller.rs
+++ b/monarch_extension/src/controller.rs
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#![cfg(feature = "tensor_engine")]
-
 /// These the controller messages that are exposed to python to allow the client to construct and
 /// send messages to the controller. For more details of the definitions take a look at
 /// [`monarch_messages::controller::ControllerMessage`].

--- a/monarch_extension/src/convert.rs
+++ b/monarch_extension/src/convert.rs
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#![cfg(feature = "tensor_engine")]
-
 use std::collections::HashMap;
 use std::sync::OnceLock;
 

--- a/monarch_extension/src/debugger.rs
+++ b/monarch_extension/src/debugger.rs
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#![cfg(feature = "tensor_engine")]
-
 use std::sync::Arc;
 
 use hyperactor::ActorRef;

--- a/monarch_extension/src/debugger.rs
+++ b/monarch_extension/src/debugger.rs
@@ -114,8 +114,10 @@ impl PdbActor {
                 async move { instance.lock().await.next_message(None).await },
             )?;
         match result {
-            Ok(Some(DebuggerMessage::Action { action })) => Ok(action.into_py(py)),
-            Ok(None) => Ok(PyNone::get(py).into_py(py)),
+            Ok(Some(DebuggerMessage::Action { action })) => {
+                Ok(action.into_pyobject(py)?.into_any().unbind())
+            }
+            Ok(None) => Ok(PyNone::get(py).as_any().clone().unbind()),
             Err(err) => Err(PyRuntimeError::new_err(err.to_string())),
         }
     }

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -68,7 +68,8 @@ impl _Controller {
     ) -> PyResult<()> {
         for (seq, response) in responses {
             let message = crate::client::WorkerResponse::new(seq, response);
-            self.pending_messages.push_back(message.into_py(py));
+            self.pending_messages
+                .push_back(message.into_pyobject(py)?.into_any().unbind());
         }
         Ok(())
     }
@@ -89,7 +90,9 @@ impl _Controller {
                     action,
                 } => {
                     let dm = crate::client::DebuggerMessage::new(debugger_actor_id.into(), action)?
-                        .into_py(py);
+                        .into_pyobject(py)?
+                        .into_any()
+                        .unbind();
                     self.pending_messages.push_back(dm);
                 }
                 ControllerMessage::Status {

--- a/monarch_extension/src/tensor_worker.rs
+++ b/monarch_extension/src/tensor_worker.rs
@@ -6,8 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#![cfg(feature = "tensor_engine")]
-
 /// These are the worker messages exposed through pyo3 to python.
 /// The actual documentation of the messages can be found in [`monarch_messages::worker::WorkerMessage`]
 /// This split is currently needed to customize the constructors for the messages and due to the

--- a/monarch_extension/src/tensor_worker.rs
+++ b/monarch_extension/src/tensor_worker.rs
@@ -1284,7 +1284,9 @@ fn wire_values_to_kwargs(py: Python<'_>, kwargs: HashMap<String, WireValue>) -> 
             }))
         })
         .collect::<Result<HashMap<_, _>, PyErr>>()?
-        .to_object(py))
+        .into_pyobject(py)?
+        .into_any()
+        .unbind())
 }
 
 // TODO: This can become an impl on WorkerMessage once we adjust crate split with monarch_messages
@@ -1294,79 +1296,137 @@ pub(crate) fn worker_message_to_py(py: Python<'_>, message: &WorkerMessage) -> P
     });
     let initializer = match message {
         WorkerMessage::BackendNetworkInit { .. } => {
-            Py::new(py, initializer.add_subclass(BackendNetworkInit {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(BackendNetworkInit {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
         WorkerMessage::BackendNetworkPointToPointInit { .. } => Py::new(
             py,
             initializer.add_subclass(BackendNetworkPointToPointInit {}),
         )?
-        .to_object(py),
+        .into_pyobject(py)?
+        .into_any()
+        .unbind(),
         WorkerMessage::CallFunction { .. } => {
-            Py::new(py, initializer.add_subclass(CallFunction {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(CallFunction {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
         WorkerMessage::CreateStream { .. } => {
-            Py::new(py, initializer.add_subclass(CreateStream {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(CreateStream {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
         WorkerMessage::CreateRemoteProcessGroup { .. } => {
-            Py::new(py, initializer.add_subclass(CreateRemoteProcessGroup {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(CreateRemoteProcessGroup {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
         WorkerMessage::CreateDeviceMesh { .. } => {
-            Py::new(py, initializer.add_subclass(CreateDeviceMesh {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(CreateDeviceMesh {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
         WorkerMessage::BorrowCreate { .. } => {
-            Py::new(py, initializer.add_subclass(BorrowCreate {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(BorrowCreate {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
         WorkerMessage::BorrowFirstUse { .. } => {
-            Py::new(py, initializer.add_subclass(BorrowFirstUse {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(BorrowFirstUse {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
         WorkerMessage::BorrowLastUse { .. } => {
-            Py::new(py, initializer.add_subclass(BorrowLastUse {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(BorrowLastUse {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
-        WorkerMessage::BorrowDrop { .. } => {
-            Py::new(py, initializer.add_subclass(BorrowDrop {}))?.to_object(py)
-        }
-        WorkerMessage::DeleteRefs { .. } => {
-            Py::new(py, initializer.add_subclass(DeleteRefs {}))?.to_object(py)
-        }
+        WorkerMessage::BorrowDrop { .. } => Py::new(py, initializer.add_subclass(BorrowDrop {}))?
+            .into_pyobject(py)?
+            .into_any()
+            .unbind(),
+        WorkerMessage::DeleteRefs { .. } => Py::new(py, initializer.add_subclass(DeleteRefs {}))?
+            .into_pyobject(py)?
+            .into_any()
+            .unbind(),
         WorkerMessage::RequestStatus { .. } => {
-            Py::new(py, initializer.add_subclass(RequestStatus {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(RequestStatus {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
-        WorkerMessage::Reduce { .. } => {
-            Py::new(py, initializer.add_subclass(Reduce {}))?.to_object(py)
-        }
-        WorkerMessage::SendTensor { .. } => {
-            Py::new(py, initializer.add_subclass(SendTensor {}))?.to_object(py)
-        }
-        WorkerMessage::CreatePipe { .. } => {
-            Py::new(py, initializer.add_subclass(CreatePipe {}))?.to_object(py)
-        }
-        WorkerMessage::SendValue { .. } => {
-            Py::new(py, initializer.add_subclass(SendValue {}))?.to_object(py)
-        }
-        WorkerMessage::PipeRecv { .. } => {
-            Py::new(py, initializer.add_subclass(PipeRecv {}))?.to_object(py)
-        }
-        WorkerMessage::SplitComm { .. } => {
-            Py::new(py, initializer.add_subclass(SplitComm {}))?.to_object(py)
-        }
+        WorkerMessage::Reduce { .. } => Py::new(py, initializer.add_subclass(Reduce {}))?
+            .into_pyobject(py)?
+            .into_any()
+            .unbind(),
+        WorkerMessage::SendTensor { .. } => Py::new(py, initializer.add_subclass(SendTensor {}))?
+            .into_pyobject(py)?
+            .into_any()
+            .unbind(),
+        WorkerMessage::CreatePipe { .. } => Py::new(py, initializer.add_subclass(CreatePipe {}))?
+            .into_pyobject(py)?
+            .into_any()
+            .unbind(),
+        WorkerMessage::SendValue { .. } => Py::new(py, initializer.add_subclass(SendValue {}))?
+            .into_pyobject(py)?
+            .into_any()
+            .unbind(),
+        WorkerMessage::PipeRecv { .. } => Py::new(py, initializer.add_subclass(PipeRecv {}))?
+            .into_pyobject(py)?
+            .into_any()
+            .unbind(),
+        WorkerMessage::SplitComm { .. } => Py::new(py, initializer.add_subclass(SplitComm {}))?
+            .into_pyobject(py)?
+            .into_any()
+            .unbind(),
         WorkerMessage::SplitCommForProcessGroup { .. } => {
-            Py::new(py, initializer.add_subclass(SplitCommForProcessGroup {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(SplitCommForProcessGroup {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
-        WorkerMessage::Exit { .. } => Py::new(py, initializer.add_subclass(Exit {}))?.to_object(py),
+        WorkerMessage::Exit { .. } => Py::new(py, initializer.add_subclass(Exit {}))?
+            .into_pyobject(py)?
+            .into_any()
+            .unbind(),
         WorkerMessage::CommandGroup { .. } => {
-            Py::new(py, initializer.add_subclass(CommandGroup {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(CommandGroup {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
         WorkerMessage::DefineRecording { .. } => {
-            Py::new(py, initializer.add_subclass(DefineRecording {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(DefineRecording {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
         WorkerMessage::RecordingFormal { .. } => {
-            Py::new(py, initializer.add_subclass(RecordingFormal {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(RecordingFormal {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
         WorkerMessage::RecordingResult { .. } => {
-            Py::new(py, initializer.add_subclass(RecordingResult {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(RecordingResult {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
         WorkerMessage::CallRecording { .. } => {
-            Py::new(py, initializer.add_subclass(CallRecording {}))?.to_object(py)
+            Py::new(py, initializer.add_subclass(CallRecording {}))?
+                .into_pyobject(py)?
+                .into_any()
+                .unbind()
         }
         WorkerMessage::SetRefUnitTestsOnly { .. } => unimplemented!(),
         WorkerMessage::GetRefUnitTestsOnly { .. } => unimplemented!(),


### PR DESCRIPTION
Summary:
```
warning: duplicated attribute
  --> fbcode/monarch/monarch_extension/src/convert.rs:9:8
   |
9  | #![cfg(feature = "tensor_engine")]
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: first defined here
  --> fbcode/monarch/monarch_extension/src/lib.rs:16:7
   |
16 | #[cfg(feature = "tensor_engine")]
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^
help: remove this attribute
  --> fbcode/monarch/monarch_extension/src/convert.rs:9:8
   |
9  | #![cfg(feature = "tensor_engine")]
   |        ^^^^^^^^^^^^^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#duplicated_attributes
   = note: `#[warn(clippy::duplicated_attributes)]` on by default

```

Differential Revision: D77060136


