### PR TITLE
Parameterize remote workspace location

### DIFF
--- a/python/monarch/_rust_bindings/monarch_extension/code_sync.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/code_sync.pyi
@@ -10,6 +10,18 @@ from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh
 
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape
 
+class RemoteWorkspace:
+    """
+    Python binding for the Rust RemoteWorkspace enum.
+    """
+    @final
+    class Constant(RemoteWorkspace):
+        def __init__(self, path) -> None: ...
+
+    @final
+    class FromEnvVar(RemoteWorkspace):
+        def __init__(self, var) -> None: ...
+
 @final
 class RsyncMeshClient:
     """
@@ -19,6 +31,7 @@ class RsyncMeshClient:
     def spawn_blocking(
         proc_mesh: ProcMesh,
         shape: Shape,
-        workspace: str,
+        local_workspace: str,
+        remote_workspace: RemoteWorkspace,
     ) -> RsyncMeshClient: ...
     async def sync_workspace(self) -> None: ...

--- a/python/monarch/code_sync.py
+++ b/python/monarch/code_sync.py
@@ -5,5 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from monarch._rust_bindings.monarch_extension.code_sync import (  # noqa: F401
+    RemoteWorkspace,
     RsyncMeshClient,
 )

--- a/python/monarch/proc_mesh.py
+++ b/python/monarch/proc_mesh.py
@@ -38,7 +38,7 @@ from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyPr
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
 from monarch.actor_mesh import _Actor, _ActorMeshRefImpl, Actor, ActorMeshRef
 
-from monarch.code_sync import RsyncMeshClient
+from monarch.code_sync import RemoteWorkspace, RsyncMeshClient
 from monarch.common._device_utils import _local_device_count
 from monarch.common.device_mesh import DeviceMesh
 from monarch.common.shape import MeshTrait
@@ -194,7 +194,8 @@ class ProcMesh(MeshTrait):
                 shape=workspace_shape,
                 # TODO(agallagher): Is there a better way to infer/set the local
                 # workspace dir, rather than use PWD?
-                workspace=os.getcwd(),
+                local_workspace=os.getcwd(),
+                remote_workspace=RemoteWorkspace.FromEnvVar("WORKSPACE_DIR"),
             )
         await self._rsync_mesh_client.sync_workspace()
 


### PR DESCRIPTION
Summary:
Rather than hard-coding reading it from `WORKSPACE_DIR` in the actor,
add an enum to pass this in.

Differential Revision: D77154764


