### PR TITLE
Support for message headers inside MessageEnvelope

### DIFF
--- a/hyperactor/src/cap.rs
+++ b/hyperactor/src/cap.rs
@@ -35,11 +35,12 @@ pub(crate) mod sealed {
     use crate::PortId;
     use crate::actor::Actor;
     use crate::actor::ActorHandle;
+    use crate::attrs::Attrs;
     use crate::data::Serialized;
     use crate::mailbox::Mailbox;
 
     pub trait CanSend: Send + Sync {
-        fn post(&self, dest: PortId, data: Serialized);
+        fn post(&self, dest: PortId, headers: Attrs, data: Serialized);
     }
 
     pub trait CanOpenPort: Send + Sync {

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -222,7 +222,7 @@ impl<M: Bind> IndexedErasedUnbound<M> {
         M: RemoteMessage,
     {
         let mailbox_clone = mailbox.clone();
-        let port_handle = mailbox.open_enqueue_port::<IndexedErasedUnbound<M>>(move |m| {
+        let port_handle = mailbox.open_enqueue_port::<IndexedErasedUnbound<M>>(move |_, m| {
             let bound_m = m.downcast()?.bind()?;
             actor_ref.send(&mailbox_clone, bound_m)?;
             Ok(())

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = "0.1.86"
 bincode = "1.3.3"
 bitmaps = "3.2.1"
 enum-as-inner = "0.6.0"
+erased-serde = "0.3.27"
 futures = { version = "0.3.30", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh_macros = { version = "0.0.0", path = "../hyperactor_mesh_macros" }

--- a/hyperactor_mesh/src/comm/mod.rs
+++ b/hyperactor_mesh/src/comm/mod.rs
@@ -22,6 +22,7 @@ use hyperactor::Instance;
 use hyperactor::Named;
 use hyperactor::PortId;
 use hyperactor::WorldId;
+use hyperactor::attrs::Attrs;
 use hyperactor::data::Serialized;
 use ndslice::Slice;
 use ndslice::selection::routing::RoutingFrame;
@@ -207,6 +208,7 @@ impl CommActor {
                     .proc_id()
                     .actor_id(message.dest_port().actor_name(), 0)
                     .port_id(message.dest_port().port()),
+                Attrs::new(),
                 Serialized::serialize(message.data())?,
             );
         }

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -11,6 +11,7 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use anyhow::Result;
+use future::Future;
 use futures::Stream;
 use futures::StreamExt;
 use futures::future;

--- a/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
+++ b/hyperactor_mesh/src/proc_mesh/mesh_agent.rs
@@ -307,6 +307,7 @@ mod tests {
     use std::sync::Arc;
     use std::sync::Mutex;
 
+    use hyperactor::attrs::Attrs;
     use hyperactor::id;
     use hyperactor::mailbox::BoxedMailboxSender;
     use hyperactor::mailbox::Mailbox;
@@ -346,8 +347,13 @@ mod tests {
 
     // Helper function to create a test message envelope
     fn envelope(data: u64) -> MessageEnvelope {
-        MessageEnvelope::serialize(id!(world[0].sender), id!(world[0].receiver[0][1]), &data)
-            .unwrap()
+        MessageEnvelope::serialize(
+            id!(world[0].sender),
+            id!(world[0].receiver[0][1]),
+            &data,
+            Attrs::new(),
+        )
+        .unwrap()
     }
 
     fn return_handle() -> PortHandle<Undeliverable<MessageEnvelope>> {

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -1815,6 +1815,7 @@ mod tests {
     use anyhow::Result;
     use hyperactor::PortId;
     use hyperactor::actor::ActorStatus;
+    use hyperactor::attrs::Attrs;
     use hyperactor::channel;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::channel::Rx;
@@ -1941,6 +1942,7 @@ mod tests {
                 local_proc_mbox.actor_id().clone(),
                 local_u64_port.bind().port_id().clone(),
                 Serialized::serialize(&123u64).unwrap(),
+                Attrs::new(),
             ),
             monitored_return_handle(),
         );
@@ -2832,6 +2834,7 @@ mod tests {
             src_id,
             PortId(id!(proc[1].actor), 9999u64),
             Serialized::serialize(&1u64).unwrap(),
+            Attrs::new(),
         ));
 
         let envelope = rx.recv().await.unwrap();

--- a/monarch_extension/src/simulator_client.rs
+++ b/monarch_extension/src/simulator_client.rs
@@ -10,6 +10,7 @@
 
 use anyhow::anyhow;
 use hyperactor::PortId;
+use hyperactor::attrs::Attrs;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::Tx;
 use hyperactor::channel::dial;
@@ -49,7 +50,7 @@ fn wrap_operational_message(operational_message: OperationalMessage) -> MessageE
     // a dummy port ID. We are delivering message with low level mailbox.
     // The port ID is not used.
     let port_id = PortId(id!(simulator[0].actor), 0);
-    MessageEnvelope::new(sender_id, port_id, serialized_proxy_message)
+    MessageEnvelope::new(sender_id, port_id, serialized_proxy_message, Attrs::new())
 }
 
 #[pyfunction]

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -18,6 +18,7 @@ use hyperactor::OncePortRef;
 use hyperactor::PortHandle;
 use hyperactor::PortId;
 use hyperactor::PortRef;
+use hyperactor::attrs::Attrs;
 use hyperactor::data::Serialized;
 use hyperactor::mailbox::MailboxSender;
 use hyperactor::mailbox::MessageEnvelope;
@@ -89,7 +90,12 @@ impl PyMailbox {
                 message, err
             ))
         })?;
-        let envelope = MessageEnvelope::new(self.inner.actor_id().clone(), port_id, message);
+        let envelope = MessageEnvelope::new(
+            self.inner.actor_id().clone(),
+            port_id,
+            message,
+            Attrs::new(),
+        );
         self.inner.post(envelope, monitored_return_handle());
         Ok(())
     }
@@ -113,7 +119,12 @@ impl PyMailbox {
                 message, err
             ))
         })?;
-        let envelope = MessageEnvelope::new(self.inner.actor_id().clone(), port_id, message);
+        let envelope = MessageEnvelope::new(
+            self.inner.actor_id().clone(),
+            port_id,
+            message,
+            Attrs::new(),
+        );
         self.inner.post(envelope, monitored_return_handle());
         Ok(())
     }

--- a/monarch_simulator/src/controller.rs
+++ b/monarch_simulator/src/controller.rs
@@ -17,6 +17,7 @@ use hyperactor::ActorId;
 use hyperactor::ActorRef;
 use hyperactor::Named;
 use hyperactor::actor::ActorHandle;
+use hyperactor::attrs::Attrs;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::data::Serialized;
 use hyperactor_multiprocess::proc_actor::ProcActor;
@@ -111,7 +112,7 @@ impl ControllerMessageHandler for SimControllerActor {
         tracing::info!("controller send to ranks {:?}: {}", ranks, message);
         self.worker_actor_ref
             .port::<WorkerMessage>()
-            .send_serialized(this, message);
+            .send_serialized(this, message, Attrs::new());
         Ok(())
     }
 


### PR DESCRIPTION
Summary:
This diff is an RFC for handling message headers. Each `MessageEnvelope` now contains a `headers` field, which leverages the attribute dictionary mariusae introduced in D76438138. In order to support this, the `caps::CanSend::post` interface now takes an additional argument `headers`.

Because `MessageEnvelope` is only used to send messages using `ActorRef`, `PortRef` and `PortId`, these are currently the only interfaces that support sending messages with headers, each with a newly added `send_with_headers` method. Moreover, to keep this diff manageably sized, headers are currently only accessible on the receiver side inside message handlers; if a non-handler port receives a message with headers, the headers will be discarded.

Inside Handler implementations, headers can be accessed via `Instance::ctx().map(|ctx| ctx.headers())`.

Reviewed By: mariusae

Differential Revision: D76532974


