### PR TITLE
Allow telemetry clock swapping at runtime

### DIFF
--- a/hyperactor/src/clock.rs
+++ b/hyperactor/src/clock.rs
@@ -12,6 +12,7 @@ use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::time::SystemTime;
 
+use hyperactor_telemetry::TelemetryClock;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -96,6 +97,22 @@ impl Clock for ClockKind {
         }
     }
     fn system_time_now(&self) -> SystemTime {
+        match self {
+            Self::Sim(clock) => clock.system_time_now(),
+            Self::Real(clock) => clock.system_time_now(),
+        }
+    }
+}
+
+impl TelemetryClock for ClockKind {
+    fn now(&self) -> tokio::time::Instant {
+        match self {
+            Self::Sim(clock) => clock.now(),
+            Self::Real(clock) => clock.now(),
+        }
+    }
+
+    fn system_time_now(&self) -> std::time::SystemTime {
         match self {
             Self::Sim(clock) => clock.system_time_now(),
             Self::Real(clock) => clock.system_time_now(),

--- a/hyperactor/src/init.rs
+++ b/hyperactor/src/init.rs
@@ -11,6 +11,7 @@
 use std::sync::LazyLock;
 use std::sync::OnceLock;
 
+use crate::clock::ClockKind;
 use crate::panic_handler;
 
 /// A global runtime used in binding async and sync code. Do not use for executing long running or
@@ -28,7 +29,7 @@ pub fn initialize() {
     static INITIALIZED: OnceLock<()> = OnceLock::new();
     INITIALIZED.get_or_init(|| {
         panic_handler::set_panic_hook();
-        hyperactor_telemetry::initialize_logging();
+        hyperactor_telemetry::initialize_logging(ClockKind::default());
         #[cfg(target_os = "linux")]
         linux::initialize();
     });

--- a/hyperactor_extension/Cargo.toml
+++ b/hyperactor_extension/Cargo.toml
@@ -11,6 +11,7 @@ license = "BSD-3-Clause"
 async-trait = "0.1.86"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
+hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 pyo3 = { version = "0.24", features = ["anyhow"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -1004,6 +1004,7 @@ mod test {
 
     use hyperactor::ActorRef;
     use hyperactor::channel::ChannelRx;
+    use hyperactor::clock::ClockKind;
     use hyperactor::id;
     use ndslice::shape;
     use tokio::sync::oneshot;
@@ -1089,7 +1090,7 @@ mod test {
 
     #[timed_test::async_timed_test(timeout_secs = 5)]
     async fn test_simple() {
-        hyperactor_telemetry::initialize_logging();
+        hyperactor_telemetry::initialize_logging(ClockKind::default());
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
         let bootstrap_addr = ChannelAddr::any(ChannelTransport::Unix);
         let (_, mut rx) = channel::serve(bootstrap_addr.clone()).await.unwrap();
@@ -1223,7 +1224,7 @@ mod test {
 
     #[timed_test::async_timed_test(timeout_secs = 15)]
     async fn test_normal_stop() {
-        hyperactor_telemetry::initialize_logging();
+        hyperactor_telemetry::initialize_logging(ClockKind::default());
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
         let bootstrap_addr = ChannelAddr::any(ChannelTransport::Unix);
         let (_, mut rx) = channel::serve(bootstrap_addr.clone()).await.unwrap();
@@ -1297,7 +1298,7 @@ mod test {
 
     #[timed_test::async_timed_test(timeout_secs = 15)]
     async fn test_realloc() {
-        hyperactor_telemetry::initialize_logging();
+        hyperactor_telemetry::initialize_logging(ClockKind::default());
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
         let bootstrap_addr = ChannelAddr::any(ChannelTransport::Unix);
         let (_, mut rx) = channel::serve(bootstrap_addr.clone()).await.unwrap();
@@ -1420,7 +1421,7 @@ mod test {
             Duration::from_secs(1),
         );
 
-        hyperactor_telemetry::initialize_logging();
+        hyperactor_telemetry::initialize_logging(ClockKind::default());
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
         let bootstrap_addr = ChannelAddr::any(ChannelTransport::Unix);
         let (_, mut rx) = channel::serve(bootstrap_addr.clone()).await.unwrap();
@@ -1502,7 +1503,7 @@ mod test {
 
     #[timed_test::async_timed_test(timeout_secs = 15)]
     async fn test_inner_alloc_failure() {
-        hyperactor_telemetry::initialize_logging();
+        hyperactor_telemetry::initialize_logging(ClockKind::default());
         let serve_addr = ChannelAddr::any(ChannelTransport::Unix);
         let bootstrap_addr = ChannelAddr::any(ChannelTransport::Unix);
         let (_, mut rx) = channel::serve(bootstrap_addr.clone()).await.unwrap();
@@ -1584,6 +1585,7 @@ mod test {
 
 #[cfg(test)]
 mod test_alloc {
+    use hyperactor::clock::ClockKind;
     use ndslice::shape;
     use timed_test::async_timed_test;
 
@@ -1597,7 +1599,7 @@ mod test_alloc {
             hyperactor::config::MESSAGE_DELIVERY_TIMEOUT,
             Duration::from_secs(1),
         );
-        hyperactor_telemetry::initialize_logging();
+        hyperactor_telemetry::initialize_logging(ClockKind::default());
 
         let spec = AllocSpec {
             shape: shape!(host = 2, gpu = 2),
@@ -1718,7 +1720,7 @@ mod test_alloc {
             hyperactor::config::MESSAGE_DELIVERY_TIMEOUT,
             Duration::from_secs(1),
         );
-        hyperactor_telemetry::initialize_logging();
+        hyperactor_telemetry::initialize_logging(ClockKind::default());
 
         let spec = AllocSpec {
             shape: shape!(host = 2, gpu = 2),
@@ -1839,7 +1841,7 @@ mod test_alloc {
         unsafe {
             std::env::set_var("MONARCH_MESSAGE_DELIVERY_TIMEOUT_SECS", "1");
         }
-        hyperactor_telemetry::initialize_logging();
+        hyperactor_telemetry::initialize_logging(ClockKind::default());
 
         let spec = AllocSpec {
             shape: shape!(host = 2, gpu = 2),

--- a/hyperactor_telemetry/tester/main.rs
+++ b/hyperactor_telemetry/tester/main.rs
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use hyperactor_telemetry::DefaultTelemetryClock;
 use hyperactor_telemetry::declare_static_counter;
 use hyperactor_telemetry::declare_static_gauge;
 use hyperactor_telemetry::declare_static_histogram;
@@ -23,6 +24,6 @@ fn something_an_actor_would_do() {
 
 fn main() {
     // Initialize logging with default configuration
-    initialize_logging();
+    initialize_logging(DefaultTelemetryClock {});
     tracing::info!("info log");
 }

--- a/python/monarch/_rust_bindings/hyperactor_extension/telemetry.pyi
+++ b/python/monarch/_rust_bindings/hyperactor_extension/telemetry.pyi
@@ -69,6 +69,23 @@ def get_current_span_id() -> int:
     """
     ...
 
+def use_real_clock() -> None:
+    """
+    Convenience function to switch to real-time clock.
+
+    This switches the telemetry system to use real system time.
+    """
+    ...
+
+def use_sim_clock() -> None:
+    """
+    Convenience function to switch to simulated clock.
+
+    This switches the telemetry system to use simulated time, which is useful for
+    testing and simulation environments where you want deterministic time control.
+    """
+    ...
+
 class PySpan:
     def __init__(self, name: str) -> None:
         """


### PR DESCRIPTION
Summary:
* Add static TELEMETRY_CLOCK to hold sim or real clock
* Use TELEMETRY_CLOCK for time_us scuba column
* initialize with default real clock
* Add python bindings to swap out the clock from py

Differential Revision: D76756737


