### PR TITLE
Delete Cast<M> and remove explicit IndexedErasedUnbound<M> from hyperactor::export

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -59,6 +59,7 @@ use monarch_messages::worker::Ref;
 use monarch_messages::worker::WorkerActor;
 use monarch_messages::worker::WorkerMessage;
 use ndslice::Selection;
+use ndslice::Shape;
 use ndslice::Slice;
 use ndslice::reshape::Limit;
 use ndslice::reshape::ReshapeSliceExt;
@@ -430,6 +431,8 @@ impl ControllerMessageHandler for ControllerActor {
                     .name()
                     .to_string(),
             ),
+            // Not reflective of the actual shape, but this is never actually used.
+            Shape::unity(),
             message,
         );
 

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -33,6 +33,7 @@ hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 inventory = "0.3.8"
 lazy_static = { version = "1.5", features = ["spin_no_std"], default-features = false }
 libc = "0.2.139"
+ndslice = { version = "0.0.0", path = "../ndslice" }
 nix = { version = "0.29.0", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
 opentelemetry = "0.29"
 paste = "1.0.14"

--- a/hyperactor/src/data.rs
+++ b/hyperactor/src/data.rs
@@ -178,6 +178,19 @@ impl<T: Named + 'static, E: Named + 'static> Named for Result<T, E> {
     }
 }
 
+static SHAPE_CACHED_TYPEHASH: LazyLock<u64> =
+    LazyLock::new(|| cityhasher::hash(<ndslice::shape::Shape as Named>::typename()));
+
+impl Named for ndslice::shape::Shape {
+    fn typename() -> &'static str {
+        "ndslice::shape::Shape"
+    }
+
+    fn typehash() -> u64 {
+        *SHAPE_CACHED_TYPEHASH
+    }
+}
+
 /// Really internal, but needs to be exposed for macro.
 #[doc(hidden)]
 #[derive(Debug)]

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -43,7 +43,6 @@ use tokio::io::AsyncWrite;
 use tokio_util::io::StreamReader;
 
 use crate::actor_mesh::ActorMesh;
-use crate::actor_mesh::Cast;
 
 // Timeout for establishing a connection, used by both client and server.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -216,9 +215,7 @@ pub async fn connect_mesh<M, A>(
 ) -> Result<()>
 where
     M: ActorMesh<Actor = A>,
-    A: RemoteActor
-        + RemoteHandles<Cast<Connect>>
-        + RemoteHandles<IndexedErasedUnbound<Cast<Connect>>>,
+    A: RemoteActor + RemoteHandles<Connect> + RemoteHandles<IndexedErasedUnbound<Connect>>,
 {
     let client = actor_mesh.proc_mesh().client();
 

--- a/hyperactor_mesh/src/test_utils.rs
+++ b/hyperactor_mesh/src/test_utils.rs
@@ -16,8 +16,6 @@ use hyperactor::Unbind;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::actor_mesh::Cast;
-
 /// Message that can be sent to an EmptyActor.
 #[derive(Serialize, Deserialize, Debug, Named, Clone, Bind, Unbind)]
 pub struct EmptyMessage();
@@ -26,8 +24,7 @@ pub struct EmptyMessage();
 #[derive(Debug, PartialEq)]
 #[hyperactor::export(
     handlers = [
-        EmptyMessage,
-        Cast<EmptyMessage> { cast = true },
+        EmptyMessage { cast = true },
     ],
 )]
 pub struct EmptyActor();
@@ -44,17 +41,6 @@ impl Actor for EmptyActor {
 #[async_trait]
 impl Handler<EmptyMessage> for EmptyActor {
     async fn handle(&mut self, _: &Instance<Self>, _: EmptyMessage) -> Result<(), anyhow::Error> {
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl Handler<Cast<EmptyMessage>> for EmptyActor {
-    async fn handle(
-        &mut self,
-        _: &Instance<Self>,
-        _: Cast<EmptyMessage>,
-    ) -> Result<(), anyhow::Error> {
         Ok(())
     }
 }


### PR DESCRIPTION
Summary:
Now that messages have headers, we can delete `Cast<M>` and remove the `Cast<M>` boilerplate from handlers. The rank and shape of a cast are now propagated via headers accessible inside message handlers that don't require explicitly specializing for `Cast<M>`.

While going through and removing all of the `Handler<Cast<M>>` implementations, and removing `Cast<M>` from `hyperactor::export`, I also noticed that for almost every message type `M` in `hyperactor::export`, we also had to explicitly export `IndexedErasedUnbound<M>` as well in order to work with casting. Since `Handler<IndexedErasedUnbound<M>>` is already implemented automatically for `M: Castable`, I thought it would make sense to also have `hyperactor::export` automatically implement `RemoteHandles<IndexedErasedUnbound<M>>`, as well as bind a port for it in the `Binds` trait. To do this, I added a `cast_handlers` attribute to `hyperactor::export`.

Differential Revision: D77183273


