### PR TITLE
python ProcMesh supervision API

### DIFF
--- a/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/proc_mesh.pyi
@@ -6,7 +6,7 @@
 
 # pyre-strict
 
-from typing import final, Type
+from typing import AsyncIterator, final, Type
 
 from monarch._rust_bindings.hyperactor_extension.alloc import Alloc
 from monarch._rust_bindings.monarch_hyperactor.actor import Actor
@@ -58,6 +58,12 @@ class ProcMesh:
         """
         ...
 
+    async def monitor(self) -> ProcMeshMonitor:
+        """
+        Returns a supervision monitor for this mesh.
+        """
+        ...
+
     @property
     def client(self) -> Mailbox:
         """
@@ -75,3 +81,35 @@ class ProcMesh:
         ...
 
     def __repr__(self) -> str: ...
+
+@final
+class ProcMeshMonitor:
+    def __aiter__(self) -> AsyncIterator["ProcEvent"]:
+        """
+        Returns an async iterator for this monitor.
+        """
+        ...
+
+    async def __anext__(self) -> "ProcEvent":
+        """
+        Returns the next proc event in the proc mesh.
+        """
+        ...
+
+@final
+class ProcEvent:
+    @final
+    class Stopped:
+        """
+        A Stopped event.
+        """
+
+        ...
+
+    @final
+    class Crashed:
+        """
+        A Crashed event.
+        """
+
+        ...

--- a/python/monarch/proc_mesh.py
+++ b/python/monarch/proc_mesh.py
@@ -38,7 +38,10 @@ from monarch._rust_bindings.hyperactor_extension.alloc import (  # @manual=//mon
     AllocSpec,
 )
 from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
-from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
+from monarch._rust_bindings.monarch_hyperactor.proc_mesh import (
+    ProcMesh as HyProcMesh,
+    ProcMeshMonitor,
+)
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape, Slice
 from monarch.actor_mesh import _Actor, _ActorMeshRefImpl, Actor, ActorMeshRef
 
@@ -116,6 +119,24 @@ class ProcMesh(MeshTrait):
             lambda: self._spawn_nonblocking(name, Class, *args, **kwargs),
             lambda: self._spawn_blocking(name, Class, *args, **kwargs),
         )
+
+    async def monitor(self) -> ProcMeshMonitor:
+        """
+        Get a monitor (async iterator) of the proc mesh, it is used to
+        monitor the status of the proc mesh. This function can be called at most once.
+
+        Note: This API is experimental and subject to change.
+
+        Example:
+
+        async def monitor_loop(monitor):
+            async for event in monitor:
+                await handle_exception_event(event)
+
+        # Kick off in background
+        asyncio.create_task(monitor_loop(monitor))
+        """
+        return await self._proc_mesh.monitor()
 
     @classmethod
     def from_alloc(self, alloc: Alloc) -> Future["ProcMesh"]:


### PR DESCRIPTION
Summary:
This diff adds supervision API to python ProcMesh class. Proc supervision events will be exposed as an async iterator.

The default behavior of supervision error handling is terminating the client process, this diff provides an API to override this behavior. User can choose to observe the supervision events on a ProcMesh via the new "monitor()" API. When observing starts, supervision error won't automatically exit the client process, instead it pass the error handling responsibility to user who is actively observing the errors.

Differential Revision: D77033984
