### PR TITLE
Strip float_roundtrip and unbounded_depth from serde_json for no_std builds

### DIFF
--- a/controller/Cargo.toml
+++ b/controller/Cargo.toml
@@ -25,7 +25,7 @@ nccl-sys = { path = "../nccl-sys" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 pyo3 = { version = "0.24", features = ["anyhow"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
-serde_json = { version = "1.0.140", features = ["float_roundtrip", "unbounded_depth"] }
+serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "unbounded_depth"] }
 tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }
 torch-sys = { path = "../torch-sys" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -43,7 +43,7 @@ rustls-pemfile = "1.0.0"
 rustls-webpki = { version = "0.101.4", features = ["alloc", "std"], default-features = false }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_bytes = "0.11"
-serde_json = { version = "1.0.140", features = ["float_roundtrip", "unbounded_depth"] }
+serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "unbounded_depth"] }
 serde_with = { version = "1.14.0", features = ["hex", "json"] }
 serde_yaml = "0.9.25"
 thiserror = "2.0.12"

--- a/hyperactor_multiprocess/Cargo.toml
+++ b/hyperactor_multiprocess/Cargo.toml
@@ -28,7 +28,7 @@ tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 maplit = "1.0"
 rand = { version = "0.8", features = ["small_rng"] }
 regex = "1.11.1"
-serde_json = { version = "1.0.140", features = ["float_roundtrip", "unbounded_depth"] }
+serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "unbounded_depth"] }
 timed_test = { version = "0.0.0", path = "../timed_test" }
 tracing-test = { version = "0.2.3", features = ["no-env-filter"] }
 

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -18,7 +18,7 @@ opentelemetry_sdk = { version = "0.29.0", features = ["rt-tokio"] }
 rand = { version = "0.8", features = ["small_rng"] }
 scuba = { version = "0.1.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main", optional = true }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
-serde_json = { version = "1.0.140", features = ["float_roundtrip", "unbounded_depth"] }
+serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "unbounded_depth"] }
 tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-appender = "0.2.3"

--- a/monarch_simulator/Cargo.toml
+++ b/monarch_simulator/Cargo.toml
@@ -26,7 +26,7 @@ monarch_tensor_worker = { version = "0.0.0", path = "../monarch_tensor_worker" }
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
-serde_json = { version = "1.0.140", features = ["float_roundtrip", "unbounded_depth"] }
+serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "unbounded_depth"] }
 thiserror = "2.0.12"
 tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }
 torch-sys = { version = "0.0.0", path = "../torch-sys" }

--- a/monarch_tensor_worker/Cargo.toml
+++ b/monarch_tensor_worker/Cargo.toml
@@ -27,7 +27,7 @@ nix = { version = "0.29.0", features = ["dir", "event", "hostname", "inotify", "
 parking_lot = { version = "0.12.1", features = ["send_guard"] }
 pyo3 = { version = "0.24", features = ["anyhow"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
-serde_json = { version = "1.0.140", features = ["float_roundtrip", "unbounded_depth"] }
+serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "unbounded_depth"] }
 sorted-vec = "0.8.3"
 tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }
 torch-sys = { version = "0.0.0", path = "../torch-sys" }


### PR DESCRIPTION
Summary:
Oak strips out `serde_json` from std builds, see https://github.com/project-oak/oak/blob/main/bazel/crates/oak_crates.bzl#L215-L219.

However, there are already `"float_roundtrip", "unbounded_depth"` features that existed before my time, so let's put these as defaults so that we're not breaking existing code that might want those features.

Reviewed By: capickett

Differential Revision: D76791926


