### PR TITLE
Correct def broadcast's docstring

### DIFF
--- a/python/monarch/actor_mesh.py
+++ b/python/monarch/actor_mesh.py
@@ -288,11 +288,11 @@ class Endpoint(Generic[P, R]):
 
     def broadcast(self, *args: P.args, **kwargs: P.kwargs) -> None:
         """
-        Broadcast to all actors and wait for each to acknowledge receipt.
+        Fire-and-forget broadcast to all actors without waiting for actors to
+        acknowledge receipt.
 
-        This behaves like `cast`, but ensures that each actor has received and
-        processed the message by awaiting a response from each one. Does not
-        return any results.
+        In other words, the return of this method does not guarrantee the
+        delivery of the message.
         """
         # pyre-ignore
         send(self, args, kwargs)


### PR DESCRIPTION
Summary:
Since `def broadcast` is just a forward of `def send`, its doc string should be consistent with `def send`. Specifically, it is a fire-and-forget, without waiting for the response.

https://www.internalfb.com/code/fbsource/[47cc2734c707599632f2c2d7ad3a5111e8535b27]/fbcode/monarch/python/monarch/actor_mesh.py?lines=359-370

Differential Revision: D77332628


