### PR TITLE
revert codemod

### DIFF
--- a/python/monarch/common/mock_cuda.cpp
+++ b/python/monarch/common/mock_cuda.cpp
@@ -439,7 +439,7 @@ std::mutex patchedMutex;
 
 void doPatch(const char* name, void** realFns, void* toPatch, void** ourFns) {
   std::lock_guard<std::mutex> guard(patchedMutex);
-  if (patched.contains(toPatch)) {
+  if (patched.count(toPatch)) {
     return;
   }
   patched.emplace(toPatch);


### PR DESCRIPTION
Summary:
This diff reverts D77210806
(The context such as a Sandcastle job, Task, SEV, etc. was not provided.)

Depends on D77210806

Reviewed By: dcci

Differential Revision: D77390627


