### PR TITLE
basic CUDA <> CPU or CUDA <> CUDA rdma Support

### DIFF
--- a/cuda-sys/src/lib.rs
+++ b/cuda-sys/src/lib.rs
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -11,7 +11,6 @@ license = "BSD-3-Clause"
 anyhow = "1.0.98"
 async-trait = "0.1.86"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
-ibverbs = "0.7.1"
 rand = { version = "0.8", features = ["small_rng"] }
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
@@ -21,3 +20,7 @@ hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 timed_test = { version = "0.0.0", path = "../timed_test" }
 tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }
+
+[features]
+cuda = []
+default = ["cuda"]

--- a/monarch_rdma/examples/Cargo.toml
+++ b/monarch_rdma/examples/Cargo.toml
@@ -13,10 +13,12 @@ path = "parameter_server.rs"
 [[bin]]
 name = "parameter_server_bootstrap"
 path = "bootstrap.rs"
+test = false
 
 [[bin]]
 name = "parameter_server_example"
 path = "main.rs"
+test = false
 
 [dependencies]
 anyhow = "1.0.98"

--- a/monarch_rdma/src/ibverbs_primitives.rs
+++ b/monarch_rdma/src/ibverbs_primitives.rs
@@ -1,10 +1,15 @@
 /*
- * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Portions Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+/*
+ * Sections of code adapted from
+ * Copyright (c) 2016 Jon Gjengset under MIT License (MIT)
+*/
 
 //! This file contains primitive data structures for interacting with ibverbs.
 //!
@@ -25,9 +30,61 @@ use std::ffi::CStr;
 use std::fmt;
 
 use hyperactor::Named;
-use ibverbs::Gid;
 use serde::Deserialize;
 use serde::Serialize;
+
+#[derive(
+    Default,
+    Copy,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize
+)]
+#[repr(transparent)]
+pub struct Gid {
+    raw: [u8; 16],
+}
+
+impl Gid {
+    #[allow(dead_code)]
+    fn subnet_prefix(&self) -> u64 {
+        u64::from_be_bytes(self.raw[..8].try_into().unwrap())
+    }
+
+    #[allow(dead_code)]
+    fn interface_id(&self) -> u64 {
+        u64::from_be_bytes(self.raw[8..].try_into().unwrap())
+    }
+}
+impl From<rdmacore_sys::ibv_gid> for Gid {
+    fn from(gid: rdmacore_sys::ibv_gid) -> Self {
+        Self {
+            raw: unsafe { gid.raw },
+        }
+    }
+}
+
+impl From<Gid> for rdmacore_sys::ibv_gid {
+    fn from(mut gid: Gid) -> Self {
+        *gid.as_mut()
+    }
+}
+
+impl AsRef<rdmacore_sys::ibv_gid> for Gid {
+    fn as_ref(&self) -> &rdmacore_sys::ibv_gid {
+        unsafe { &*self.raw.as_ptr().cast::<rdmacore_sys::ibv_gid>() }
+    }
+}
+
+impl AsMut<rdmacore_sys::ibv_gid> for Gid {
+    fn as_mut(&mut self) -> &mut rdmacore_sys::ibv_gid {
+        unsafe { &mut *self.raw.as_mut_ptr().cast::<rdmacore_sys::ibv_gid>() }
+    }
+}
 
 /// Represents ibverbs specific configurations.
 ///
@@ -86,7 +143,7 @@ impl Default for IbverbsConfig {
             max_recv_wr: 1,
             max_send_sge: 1,
             max_recv_sge: 1,
-            path_mtu: ffi::IBV_MTU_1024,
+            path_mtu: rdmacore_sys::IBV_MTU_1024,
             retry_cnt: 7,
             rnr_retry: 7,
             qp_timeout: 14, // 4.096 μs * 2^14 = ~67 ms
@@ -144,7 +201,7 @@ impl std::fmt::Display for IbverbsConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RdmaDevice {
     /// `name` - The name of the RDMA device (e.g., "mlx5_0").
-    name: String,
+    pub name: String,
     /// `vendor_id` - The vendor ID of the device.
     vendor_id: u32,
     /// `vendor_part_id` - The vendor part ID of the device.
@@ -330,10 +387,10 @@ impl fmt::Display for RdmaPort {
 /// # Returns
 ///
 /// A string representation of the port state.
-pub fn get_port_state_str(state: ffi::ibv_port_state::Type) -> String {
+pub fn get_port_state_str(state: rdmacore_sys::ibv_port_state::Type) -> String {
     // SAFETY: We are calling a C function that returns a C string.
     unsafe {
-        let c_str = ffi::ibv_port_state_str(state);
+        let c_str = rdmacore_sys::ibv_port_state_str(state);
         if c_str.is_null() {
             return "Unknown".to_string();
         }
@@ -428,7 +485,7 @@ pub fn get_all_devices() -> Vec<RdmaDevice> {
     // SAFETY: We are calling several C functions from libibverbs.
     unsafe {
         let mut num_devices = 0;
-        let device_list = ffi::ibv_get_device_list(&mut num_devices);
+        let device_list = rdmacore_sys::ibv_get_device_list(&mut num_devices);
         if device_list.is_null() || num_devices == 0 {
             return devices;
         }
@@ -439,18 +496,18 @@ pub fn get_all_devices() -> Vec<RdmaDevice> {
                 continue;
             }
 
-            let context = ffi::ibv_open_device(device);
+            let context = rdmacore_sys::ibv_open_device(device);
             if context.is_null() {
                 continue;
             }
 
-            let device_name = CStr::from_ptr(ffi::ibv_get_device_name(device))
+            let device_name = CStr::from_ptr(rdmacore_sys::ibv_get_device_name(device))
                 .to_string_lossy()
                 .into_owned();
 
-            let mut device_attr = ffi::ibv_device_attr::default();
-            if ffi::ibv_query_device(context, &mut device_attr) != 0 {
-                ffi::ibv_close_device(context);
+            let mut device_attr = rdmacore_sys::ibv_device_attr::default();
+            if rdmacore_sys::ibv_query_device(context, &mut device_attr) != 0 {
+                rdmacore_sys::ibv_close_device(context);
                 continue;
             }
 
@@ -475,11 +532,11 @@ pub fn get_all_devices() -> Vec<RdmaDevice> {
             };
 
             for port_num in 1..=device_attr.phys_port_cnt {
-                let mut port_attr = ffi::ibv_port_attr::default();
-                if ffi::ibv_query_port(
+                let mut port_attr = rdmacore_sys::ibv_port_attr::default();
+                if rdmacore_sys::ibv_query_port(
                     context,
                     port_num,
-                    &mut port_attr as *mut ffi::ibv_port_attr as *mut _,
+                    &mut port_attr as *mut rdmacore_sys::ibv_port_attr as *mut _,
                 ) != 0
                 {
                     continue;
@@ -489,8 +546,8 @@ pub fn get_all_devices() -> Vec<RdmaDevice> {
 
                 let link_layer = get_link_layer_str(port_attr.link_layer);
 
-                let mut gid = ffi::ibv_gid::default();
-                let gid_str = if ffi::ibv_query_gid(context, port_num, 0, &mut gid) == 0 {
+                let mut gid = rdmacore_sys::ibv_gid::default();
+                let gid_str = if rdmacore_sys::ibv_query_gid(context, port_num, 0, &mut gid) == 0 {
                     format_gid(&gid.raw)
                 } else {
                     "N/A".to_string()
@@ -513,10 +570,10 @@ pub fn get_all_devices() -> Vec<RdmaDevice> {
             }
 
             devices.push(rdma_device);
-            ffi::ibv_close_device(context);
+            rdmacore_sys::ibv_close_device(context);
         }
 
-        ffi::ibv_free_device_list(device_list);
+        rdmacore_sys::ibv_free_device_list(device_list);
     }
 
     devices
@@ -535,9 +592,9 @@ pub fn ibverbs_supported() -> bool {
     // SAFETY: We are calling a C function from libibverbs.
     unsafe {
         let mut num_devices = 0;
-        let device_list = ffi::ibv_get_device_list(&mut num_devices);
+        let device_list = rdmacore_sys::ibv_get_device_list(&mut num_devices);
         if !device_list.is_null() {
-            ffi::ibv_free_device_list(device_list);
+            rdmacore_sys::ibv_free_device_list(device_list);
             return true;
         }
         false
@@ -557,6 +614,7 @@ pub fn ibverbs_supported() -> bool {
 /// RDMA operations are in progress.
 #[derive(Debug, PartialEq, Eq, std::hash::Hash, Serialize, Deserialize, Clone)]
 pub struct RdmaMemoryRegionView {
+    pub id: u32,
     pub addr: usize,
     pub size: usize,
     pub lkey: u32,
@@ -582,8 +640,9 @@ unsafe impl Sync for RdmaMemoryRegionView {}
 
 impl RdmaMemoryRegionView {
     /// Creates a new `RdmaMemoryRegionView` with the given address and size.
-    pub fn new(addr: usize, size: usize, lkey: u32, rkey: u32) -> Self {
+    pub fn new(id: u32, addr: usize, size: usize, lkey: u32, rkey: u32) -> Self {
         Self {
+            id,
             addr,
             size,
             lkey,
@@ -612,20 +671,20 @@ pub enum RdmaOperation {
     Read,
 }
 
-impl From<RdmaOperation> for ffi::ibv_wr_opcode::Type {
+impl From<RdmaOperation> for rdmacore_sys::ibv_wr_opcode::Type {
     fn from(op: RdmaOperation) -> Self {
         match op {
-            RdmaOperation::Write => ffi::ibv_wr_opcode::IBV_WR_RDMA_WRITE,
-            RdmaOperation::Read => ffi::ibv_wr_opcode::IBV_WR_RDMA_READ,
+            RdmaOperation::Write => rdmacore_sys::ibv_wr_opcode::IBV_WR_RDMA_WRITE,
+            RdmaOperation::Read => rdmacore_sys::ibv_wr_opcode::IBV_WR_RDMA_READ,
         }
     }
 }
 
-impl From<ffi::ibv_wc_opcode::Type> for RdmaOperation {
-    fn from(op: ffi::ibv_wc_opcode::Type) -> Self {
+impl From<rdmacore_sys::ibv_wc_opcode::Type> for RdmaOperation {
+    fn from(op: rdmacore_sys::ibv_wc_opcode::Type) -> Self {
         match op {
-            ffi::ibv_wc_opcode::IBV_WC_RDMA_WRITE => RdmaOperation::Write,
-            ffi::ibv_wc_opcode::IBV_WC_RDMA_READ => RdmaOperation::Read,
+            rdmacore_sys::ibv_wc_opcode::IBV_WC_RDMA_WRITE => RdmaOperation::Write,
+            rdmacore_sys::ibv_wc_opcode::IBV_WC_RDMA_READ => RdmaOperation::Read,
             _ => panic!("Unsupported operation type"),
         }
     }
@@ -660,7 +719,7 @@ impl std::fmt::Debug for RdmaQpInfo {
 
 /// Wrapper around ibv_wc (ibverbs work completion).
 ///
-/// This exposes only the public fields of ffi::ibv_wc, allowing us to more easily
+/// This exposes only the public fields of rdmacore_sys::ibv_wc, allowing us to more easily
 /// interact with it from Rust. Work completions are used to track the status of
 /// RDMA operations and are generated when an operation completes.
 #[derive(Debug, Named, Clone, serde::Serialize, serde::Deserialize)]
@@ -672,9 +731,9 @@ pub struct IbvWc {
     /// `valid` - Whether the work completion is valid
     valid: bool,
     /// `error` - Error information if the operation failed
-    error: Option<(ffi::ibv_wc_status::Type, u32)>,
+    error: Option<(rdmacore_sys::ibv_wc_status::Type, u32)>,
     /// `opcode` - Type of operation that completed (read, write, etc.)
-    opcode: ffi::ibv_wc_opcode::Type,
+    opcode: rdmacore_sys::ibv_wc_opcode::Type,
     /// `bytes` - Immediate data (if any)
     bytes: Option<u32>,
     /// `qp_num` - Queue Pair Number
@@ -691,8 +750,8 @@ pub struct IbvWc {
     dlid_path_bits: u8,
 }
 
-impl From<ffi::ibv_wc> for IbvWc {
-    fn from(wc: ffi::ibv_wc) -> Self {
+impl From<rdmacore_sys::ibv_wc> for IbvWc {
+    fn from(wc: rdmacore_sys::ibv_wc) -> Self {
         IbvWc {
             wr_id: wc.wr_id(),
             len: wc.len(),
@@ -804,21 +863,21 @@ mod tests {
     #[test]
     fn test_rdma_operation_conversion() {
         assert_eq!(
-            ffi::ibv_wr_opcode::IBV_WR_RDMA_WRITE,
-            ffi::ibv_wr_opcode::Type::from(RdmaOperation::Write)
+            rdmacore_sys::ibv_wr_opcode::IBV_WR_RDMA_WRITE,
+            rdmacore_sys::ibv_wr_opcode::Type::from(RdmaOperation::Write)
         );
         assert_eq!(
-            ffi::ibv_wr_opcode::IBV_WR_RDMA_READ,
-            ffi::ibv_wr_opcode::Type::from(RdmaOperation::Read)
+            rdmacore_sys::ibv_wr_opcode::IBV_WR_RDMA_READ,
+            rdmacore_sys::ibv_wr_opcode::Type::from(RdmaOperation::Read)
         );
 
         assert_eq!(
             RdmaOperation::Write,
-            RdmaOperation::from(ffi::ibv_wc_opcode::IBV_WC_RDMA_WRITE)
+            RdmaOperation::from(rdmacore_sys::ibv_wc_opcode::IBV_WC_RDMA_WRITE)
         );
         assert_eq!(
             RdmaOperation::Read,
-            RdmaOperation::from(ffi::ibv_wc_opcode::IBV_WC_RDMA_READ)
+            RdmaOperation::from(rdmacore_sys::ibv_wc_opcode::IBV_WC_RDMA_READ)
         );
     }
 
@@ -839,18 +898,18 @@ mod tests {
 
     #[test]
     fn test_ibv_wc() {
-        let mut wc = ffi::ibv_wc::default();
+        let mut wc = rdmacore_sys::ibv_wc::default();
 
         // SAFETY: modifies private fields through pointer manipulation
         unsafe {
             // Cast to pointer and modify the fields directly
-            let wc_ptr = &mut wc as *mut ffi::ibv_wc as *mut u8;
+            let wc_ptr = &mut wc as *mut rdmacore_sys::ibv_wc as *mut u8;
 
             // Set wr_id (at offset 0, u64)
             *(wc_ptr as *mut u64) = 42;
 
             // Set status to SUCCESS (at offset 8, u32)
-            *(wc_ptr.add(8) as *mut i32) = ffi::ibv_wc_status::IBV_WC_SUCCESS as i32;
+            *(wc_ptr.add(8) as *mut i32) = rdmacore_sys::ibv_wc_status::IBV_WC_SUCCESS as i32;
         }
         let ibv_wc = IbvWc::from(wc);
         assert_eq!(ibv_wc.wr_id(), 42);

--- a/monarch_rdma/src/lib.rs
+++ b/monarch_rdma/src/lib.rs
@@ -6,10 +6,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// RDMA requires frequent unsafe code blocks
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 mod ibverbs_primitives;
 mod rdma_components;
 mod rdma_manager_actor;
 mod test_utils;
+
+#[macro_use]
+mod macros;
 
 pub use ibverbs_primitives::*;
 pub use rdma_components::*;

--- a/monarch_rdma/src/macros.rs
+++ b/monarch_rdma/src/macros.rs
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#[macro_export]
+macro_rules! cu_check {
+    ($result:expr) => {
+        if $result != cuda_sys::CUresult::CUDA_SUCCESS {
+            let mut error_string: *const i8 = std::ptr::null();
+            cuda_sys::cuGetErrorString($result, &mut error_string);
+            panic!(
+                "cuda failure {}:{} {:?} '{}'",
+                file!(),
+                line!(),
+                $result,
+                std::ffi::CStr::from_ptr(error_string).to_string_lossy()
+            );
+        }
+    };
+}

--- a/monarch_rdma/src/test_utils.rs
+++ b/monarch_rdma/src/test_utils.rs
@@ -6,44 +6,393 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::time::Duration;
-use std::time::Instant;
+#[cfg(test)]
+pub mod test_utils {
+    use std::time::Duration;
+    use std::time::Instant;
 
-use hyperactor::clock::Clock;
-use hyperactor::clock::RealClock;
+    use hyperactor::ActorRef;
+    use hyperactor::Mailbox;
+    use hyperactor::clock::Clock;
+    use hyperactor::clock::RealClock;
+    use hyperactor_mesh::Mesh;
+    use hyperactor_mesh::ProcMesh;
+    use hyperactor_mesh::RootActorMesh;
+    use hyperactor_mesh::alloc::AllocSpec;
+    use hyperactor_mesh::alloc::Allocator;
+    use hyperactor_mesh::alloc::LocalAllocator;
+    use ndslice::shape;
 
-use crate::rdma_components::RdmaQueuePair;
+    use crate::IbverbsConfig;
+    use crate::RdmaBuffer;
+    use crate::cu_check;
+    use crate::ibverbs_primitives::get_all_devices;
+    use crate::rdma_components::RdmaQueuePair;
+    use crate::rdma_manager_actor::RdmaManagerActor;
+    use crate::rdma_manager_actor::RdmaManagerMessageClient;
 
-// Waits for the completion of an RDMA operation.
+    // Waits for the completion of an RDMA operation.
 
-// This function polls for the completion of an RDMA operation by repeatedly
-// sending a `PollCompletion` message to the specified actor mesh and checking
-// the returned work completion status. It continues polling until the operation
-// completes or the specified timeout is reached.
+    // This function polls for the completion of an RDMA operation by repeatedly
+    // sending a `PollCompletion` message to the specified actor mesh and checking
+    // the returned work completion status. It continues polling until the operation
+    // completes or the specified timeout is reached.
 
-#[allow(dead_code)]
-pub async fn wait_for_completion(
-    qp: &RdmaQueuePair,
-    timeout_secs: u64,
-) -> Result<bool, anyhow::Error> {
-    let timeout = Duration::from_secs(timeout_secs);
-    let start_time = Instant::now();
+    pub async fn wait_for_completion(
+        qp: &RdmaQueuePair,
+        timeout_secs: u64,
+    ) -> Result<bool, anyhow::Error> {
+        let timeout = Duration::from_secs(timeout_secs);
+        let start_time = Instant::now();
 
-    while start_time.elapsed() < timeout {
-        match qp.poll_completion() {
-            Ok(Some(wc)) => {
-                if wc.wr_id() == 0 {
-                    return Ok(true);
+        while start_time.elapsed() < timeout {
+            match qp.poll_completion() {
+                Ok(Some(wc)) => {
+                    if wc.wr_id() == 0 {
+                        return Ok(true);
+                    }
+                }
+                Ok(None) => {
+                    RealClock.sleep(Duration::from_millis(1)).await;
+                }
+                Err(e) => {
+                    return Err(anyhow::anyhow!(e));
                 }
             }
-            Ok(None) => {
-                RealClock.sleep(Duration::from_millis(1)).await;
-            }
-            Err(e) => {
-                return Err(anyhow::anyhow!(e));
-            }
         }
+
+        Ok(false)
     }
 
-    Ok(false)
+    pub struct RdmaManagerTestEnv<'a> {
+        buffer_1: Buffer,
+        buffer_2: Buffer,
+        pub client_1: &'a Mailbox,
+        pub client_2: &'a Mailbox,
+        pub actor_1: ActorRef<RdmaManagerActor>,
+        pub actor_2: ActorRef<RdmaManagerActor>,
+        pub rdma_handle_1: RdmaBuffer,
+        pub rdma_handle_2: RdmaBuffer,
+        handle_1_cuda: bool,
+        handle_2_cuda: bool,
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct Buffer {
+        ptr: u64,
+        len: usize,
+    }
+    impl RdmaManagerTestEnv<'_> {
+        /// Sets up the RDMA test environment.
+        ///
+        /// This function initializes the RDMA test environment by setting up two actor meshes
+        /// with their respective RDMA configurations. It also prepares two buffers for testing
+        /// RDMA operations and fills the first buffer with test data.
+        ///
+        /// # Arguments
+        ///
+        /// * `buffer_size` - The size of the buffers to be used in the test.
+        /// * `devices` - Optional tuple specifying the indices of RDMA devices to use. If not provided, then
+        ///   both RDMAManagerActors will default to the first indexed RDMA device.
+        pub async fn setup(
+            buffer_size: usize,
+            nics: (&str, &str),
+            devices: (&str, &str),
+        ) -> Result<Self, anyhow::Error> {
+            let all_devices = get_all_devices();
+            let mut config1 = None;
+            let mut config2 = None;
+
+            for device in all_devices.iter() {
+                if device.name == nics.0 {
+                    config1 = Some(IbverbsConfig {
+                        device: device.clone(),
+                        ..Default::default()
+                    });
+                }
+                if device.name == nics.1 {
+                    config2 = Some(IbverbsConfig {
+                        device: device.clone(),
+                        ..Default::default()
+                    });
+                }
+            }
+            assert!(config1.is_some() && config2.is_some());
+
+            let device_str1 = (String::new(), 0);
+            let device_str2 = (String::new(), 0);
+
+            if let Some((backend, idx)) = devices.0.split_once(':') {
+                assert!(backend == "cuda");
+                let parsed_idx = idx
+                    .parse::<usize>()
+                    .expect("Device index is not a valid integer");
+                let device_str1 = (backend.to_string(), parsed_idx.to_string());
+            } else {
+                assert!(devices.0 == "cpu");
+                let device_str1 = (devices.0.to_string(), 0);
+            }
+
+            if let Some((backend, idx)) = devices.1.split_once(':') {
+                assert!(backend == "cuda");
+                let parsed_idx = idx
+                    .parse::<usize>()
+                    .expect("Device index is not a valid integer");
+                let device_str1 = (backend.to_string(), parsed_idx.to_string());
+            } else {
+                assert!(devices.1 == "cpu");
+                let device_str2 = (devices.1.to_string(), 0);
+            }
+
+            let alloc_1 = LocalAllocator
+                .allocate(AllocSpec {
+                    shape: shape! { proc = 1 },
+                    constraints: Default::default(),
+                })
+                .await
+                .unwrap();
+
+            let proc_mesh_1 = Box::leak(Box::new(ProcMesh::allocate(alloc_1).await.unwrap()));
+            let actor_mesh_1: RootActorMesh<'_, RdmaManagerActor> = proc_mesh_1
+                .spawn("rdma_manager", &(config1.unwrap()))
+                .await
+                .unwrap();
+
+            let alloc_2 = LocalAllocator
+                .allocate(AllocSpec {
+                    shape: shape! { proc = 1 },
+                    constraints: Default::default(),
+                })
+                .await
+                .unwrap();
+
+            let proc_mesh_2 = Box::leak(Box::new(ProcMesh::allocate(alloc_2).await.unwrap()));
+            let actor_mesh_2: RootActorMesh<'_, RdmaManagerActor> = proc_mesh_2
+                .spawn("rdma_manager", &(config2.unwrap()))
+                .await
+                .unwrap();
+
+            let mut buf_vec = Vec::new();
+
+            for device_str in [device_str1.clone(), device_str2.clone()] {
+                if device_str.0 != "cpu" {
+                    let mut buffer = vec![0u8; buffer_size].into_boxed_slice();
+                    buf_vec.push(Buffer {
+                        ptr: buffer.as_mut_ptr() as u64,
+                        len: buffer.len(),
+                    });
+                    continue;
+                }
+                // CUDA case
+                unsafe {
+                    cu_check!(cuda_sys::cuInit(0));
+
+                    let mut dptr: cuda_sys::CUdeviceptr = unsafe { std::mem::zeroed() };
+                    let mut handle: cuda_sys::CUmemGenericAllocationHandle =
+                        unsafe { std::mem::zeroed() };
+                    let mut padded_size: usize = 0;
+
+                    let mut device: cuda_sys::CUdevice = std::mem::zeroed();
+                    cu_check!(cuda_sys::cuDeviceGet(&mut device, device_str.1));
+
+                    let mut context: cuda_sys::CUcontext = std::mem::zeroed();
+                    cu_check!(cuda_sys::cuCtxCreate_v2(&mut context, 0, device_str.1));
+                    cu_check!(cuda_sys::cuCtxSetCurrent(context));
+
+                    let mut granularity: usize = 0;
+                    let mut prop: cuda_sys::CUmemAllocationProp = std::mem::zeroed();
+                    prop.type_ = cuda_sys::CUmemAllocationType::CU_MEM_ALLOCATION_TYPE_PINNED;
+                    prop.location.type_ = cuda_sys::CUmemLocationType::CU_MEM_LOCATION_TYPE_DEVICE;
+                    prop.location.id = device;
+                    prop.allocFlags.gpuDirectRDMACapable = 1;
+                    prop.requestedHandleTypes =
+                        cuda_sys::CUmemAllocationHandleType::CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+
+                    cu_check!(cuda_sys::cuMemGetAllocationGranularity(
+                        &mut granularity as *mut usize,
+                        &prop,
+                        cuda_sys::CUmemAllocationGranularity_flags::CU_MEM_ALLOC_GRANULARITY_MINIMUM,
+                    ));
+
+                    println!("granularity: {}", granularity);
+                    // ensure our size is aligned
+                    padded_size = ((buffer_size - 1) / granularity + 1) * granularity;
+                    assert!(padded_size == buffer_size);
+
+                    cu_check!(cuda_sys::cuMemCreate(
+                        &mut handle as *mut cuda_sys::CUmemGenericAllocationHandle,
+                        padded_size,
+                        &prop,
+                        0
+                    ));
+                    println!("cuMemCreate done");
+                    // reserve and map the memory
+                    // let mut dptr: cuda_sys::CUdeviceptr = std::mem::zeroed();
+                    cu_check!(cuda_sys::cuMemAddressReserve(
+                        &mut dptr as *mut cuda_sys::CUdeviceptr,
+                        padded_size,
+                        0,
+                        0,
+                        0,
+                    ));
+                    println!("cuMemAddressReserve done");
+                    println!("dptr: 0x{:x}", dptr);
+                    println!("padded_size: {:?}", padded_size);
+                    println!("handle: {:?}", handle);
+
+                    assert!(dptr as usize % granularity == 0);
+                    assert!(padded_size % granularity == 0);
+
+                    // fails if a add cu_check macro; but passes if we don't
+                    let err = cuda_sys::cuMemMap(
+                        dptr as cuda_sys::CUdeviceptr,
+                        padded_size,
+                        0,
+                        handle as cuda_sys::CUmemGenericAllocationHandle,
+                        0,
+                    );
+                    if err != cuda_sys::CUresult::CUDA_SUCCESS {
+                        panic!("failed reserving and mapping memory {:?}", err);
+                    }
+
+                    // set access
+                    let mut access_desc: cuda_sys::CUmemAccessDesc = std::mem::zeroed();
+                    access_desc.location.type_ =
+                        cuda_sys::CUmemLocationType::CU_MEM_LOCATION_TYPE_DEVICE;
+                    access_desc.location.id = device;
+                    access_desc.flags =
+                        cuda_sys::CUmemAccess_flags::CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+                    println!("mem set access");
+                    cu_check!(cuda_sys::cuMemSetAccess(dptr, padded_size, &access_desc, 1));
+                    println!("mem set access completed");
+                    buf_vec.push(Buffer {
+                        ptr: dptr,
+                        len: padded_size,
+                    });
+                }
+            }
+
+            let buffer1 = vec![0u8; buffer_size].into_boxed_slice();
+            let buffer2 = vec![0u8; buffer_size].into_boxed_slice();
+            // Fill buffer1 with test data
+            if device_str1.0 == "cuda" {
+                let mut temp_buffer = vec![0u8; buffer_size].into_boxed_slice();
+                for (i, val) in temp_buffer.iter_mut().enumerate() {
+                    *val = (i % 256) as u8;
+                }
+                unsafe {
+                    cu_check!(cuda_sys::cuMemcpyHtoD_v2(
+                        buf_vec[0].ptr,
+                        temp_buffer.as_ptr() as *const std::ffi::c_void,
+                        temp_buffer.len()
+                    ));
+                }
+            } else {
+                unsafe {
+                    let ptr = buf_vec[0].ptr as *mut u8; // or *const u8
+                    for i in 0..buf_vec[0].len {
+                        *ptr.add(i) = (i % 256) as u8;
+                    }
+                }
+            }
+
+            let actor_1 = actor_mesh_1.get(0).unwrap();
+            let actor_2 = actor_mesh_2.get(0).unwrap();
+
+            let rdma_handle_1 = actor_1
+                .request_buffer(proc_mesh_1.client(), buf_vec[0].ptr as usize, buffer_size)
+                .await?;
+            let rdma_handle_2 = actor_2
+                .request_buffer(proc_mesh_2.client(), buf_vec[1].ptr as usize, buffer_size)
+                .await?;
+            // Get keys from both actors.
+
+            Ok(Self {
+                buffer_1: buf_vec[0].clone(),
+                buffer_2: buf_vec[1].clone(),
+                client_1: proc_mesh_1.client(),
+                client_2: proc_mesh_2.client(),
+                actor_1,
+                actor_2,
+                rdma_handle_1,
+                rdma_handle_2,
+                handle_1_cuda: device_str1.0 == "cuda",
+                handle_2_cuda: device_str2.0 == "cuda",
+            })
+        }
+
+        pub async fn cleanup(self) -> Result<(), anyhow::Error> {
+            self.actor_1
+                .release_buffer(self.client_1, self.rdma_handle_1.clone())
+                .await?;
+            self.actor_2
+                .release_buffer(self.client_2, self.rdma_handle_2.clone())
+                .await?;
+            if self.handle_1_cuda {
+                unsafe {
+                    cu_check!(cuda_sys::cuMemUnmap(
+                        self.buffer_1.ptr as cuda_sys::CUdeviceptr,
+                        self.buffer_1.len
+                    ));
+                    cu_check!(cuda_sys::cuMemAddressFree(
+                        self.buffer_1.ptr as cuda_sys::CUdeviceptr,
+                        self.buffer_1.len
+                    ));
+                }
+            }
+            if self.handle_2_cuda {
+                unsafe {
+                    cu_check!(cuda_sys::cuMemUnmap(
+                        self.buffer_2.ptr as cuda_sys::CUdeviceptr,
+                        self.buffer_2.len
+                    ));
+                    cu_check!(cuda_sys::cuMemAddressFree(
+                        self.buffer_2.ptr as cuda_sys::CUdeviceptr,
+                        self.buffer_2.len
+                    ));
+                }
+            }
+            Ok(())
+        }
+
+        pub async fn verify_buffers(&self, size: usize) -> Result<(), anyhow::Error> {
+            let mut buf_vec = Vec::new();
+            for (handle, is_cuda) in [
+                (self.rdma_handle_1.clone(), self.handle_1_cuda),
+                (self.rdma_handle_2.clone(), self.handle_2_cuda),
+            ] {
+                if is_cuda {
+                    let mut temp_buffer = vec![0u8; size].into_boxed_slice();
+                    // SAFETY: The buffer is allocated with the correct size and the pointer is valid.
+                    unsafe {
+                        cu_check!(cuda_sys::cuMemcpyDtoH_v2(
+                            temp_buffer.as_mut_ptr() as *mut std::ffi::c_void,
+                            handle.addr as cuda_sys::CUdeviceptr,
+                            size
+                        ));
+                    }
+                    buf_vec.push(Buffer {
+                        ptr: temp_buffer.as_mut_ptr() as u64,
+                        len: size,
+                    });
+                } else {
+                    buf_vec.push(Buffer {
+                        ptr: handle.addr as u64,
+                        len: size,
+                    });
+                }
+            }
+            // SAFETY: The pointers are valid and the buffers have the same length.
+            unsafe {
+                let ptr1 = buf_vec[0].ptr as *mut u8;
+                let ptr2: *mut u8 = buf_vec[1].ptr as *mut u8;
+                for i in 0..buf_vec[0].len {
+                    if *ptr1.add(i) != *ptr2.add(i) {
+                        return Err(anyhow::anyhow!("Buffers are not equal at index {}", i));
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
 }


### PR DESCRIPTION
Summary:
RDMA support for CUDA <> CUDA and CUDA <> CPU comms

Key changes
- using cuda apis we can detect if a given pointer is mapped to a cuda device, or cpu.
- if data pointer is cuda, the code leverages dma registration to register with NIC; we are able to avoid directly passing with cuda allocation handles using cuMemGetHandleForAddressRange.
- if data pointer is cpu, we use standard ibv mr; note I transitioned to using standard registration, not entire memory space (security concern raised by mariusae)
- Refactored test infra to support named NIC devices, and different compute (cuda:X or cpu)

This implementation is relatively naive, and I will iterate accordingly.

To Do: add unit test for cuda/cuda

Differential Revision: D77408653


