### PR TITLE
Change logs to asserts related to `ChildStopped`

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1010,9 +1010,7 @@ impl<A: Actor> Instance<A> {
         while self.cell.child_count() > 0 {
             match self.signal_receiver.recv().await? {
                 Signal::ChildStopped(pid) => {
-                    if let Some(child) = self.cell.get_child(pid) {
-                        self.cell.unlink(&child);
-                    }
+                    assert!(self.cell.get_child(pid).is_none());
                 }
                 _ => (),
             }
@@ -1057,12 +1055,7 @@ impl<A: Actor> Instance<A> {
                             break 'messages;
                         },
                         Signal::ChildStopped(pid) => {
-                            let result = self.cell.get_child(pid);
-                            if let Some(child) = result {
-                                self.cell.unlink(&child);
-                            } else {
-                                tracing::warn!("received signal for unknown child pid {}", pid);
-                            }
+                            assert!(self.cell.get_child(pid).is_none());
                         },
                     }
                 }


### PR DESCRIPTION
Summary:
Children should have been unlinked before the `ChildStopped` signal was sent:

https://www.internalfb.com/code/fbsource/[075311be8caaa54d5a8a8269bd12d6bb700dfa65]/fbcode/monarch/hyperactor/src/proc.rs?lines=919-921

Differential Revision: D77456838


