### PR TITLE
[monarch]: explicitly compile C++ with -std=gnu++20

### DIFF
--- a/nccl-sys/build.rs
+++ b/nccl-sys/build.rs
@@ -80,7 +80,11 @@ fn python_env_dirs() -> (Option<String>, Option<String>) {
 
 fn main() {
     let mut builder = bindgen::Builder::default()
+        // Parse nccl.h as C++ with -std=gnu++20.
         .header("src/nccl.h")
+        .clang_arg("-x")
+        .clang_arg("c++")
+        .clang_arg("-std=gnu++20")
         .clang_arg(format!("-I{}/include", find_cuda_home().unwrap()))
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // Communicator creation and management

--- a/torch-sys-cuda/build.rs
+++ b/torch-sys-cuda/build.rs
@@ -151,7 +151,7 @@ fn main() {
     CFG.include_prefix = "monarch/torch-sys-cuda";
     let _builder = cxx_build::bridge("src/bridge.rs")
         .file("src/bridge.cpp")
-        .std("c++20")
+        .flag("-std=gnu++20")
         .includes(&libtorch_include_dirs)
         .include(python_include.unwrap())
         .include(python_include_dir.unwrap())

--- a/torch-sys/build.rs
+++ b/torch-sys/build.rs
@@ -149,7 +149,7 @@ fn main() {
             "-I{}",
             python_include_dir.clone().unwrap().display()
         ))
-        .clang_arg("-std=c++20")
+        .clang_arg("-std=gnu++20")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .allowlist_type("c10::MemoryFormat")
         .allowlist_type("c10::ScalarType")


### PR DESCRIPTION
update build.rs files to be explicit in their use of clang flag `-std=gnu++20` 