### PR TITLE
Add mesh_type arg to actor_paft

### DIFF
--- a/hyperactor_extension/src/telemetry.rs
+++ b/hyperactor_extension/src/telemetry.rs
@@ -106,7 +106,6 @@ pub fn use_real_clock() -> PyResult<()> {
 
 #[pyfunction]
 pub fn use_sim_clock() -> PyResult<()> {
-    println!("Using simulated clock");
     swap_telemetry_clock(ClockKind::Sim(SimClock));
     Ok(())
 }


### PR DESCRIPTION
Summary:
Support creating 3 different types of meshes in the paft actor example, to be used for sim testing
* thread (local)
* process (local)
* mast (remote)

To run on a single process

```
buck run @//mode/opt //monarch/examples/meta/paft:actor_paft -- --mesh_type local --group_size 2
```

To run on multi process
```
> buck run @//mode/opt //monarch/examples/meta/paft:actor_paft -- --mesh_type process --group_size 2
```

To run on mast
1. Pre boot up Mast hosts P1850132492

2.
```
buck run @//mode/opt //monarch/examples/meta/paft:actor_paft -- --mesh_type mast --mast_job_name interactive-monarch-nightly_2n-qlh42j --group_size 2
```

to get the perfetto trace
```
> buck run @//mode/dev-nosan //scripts/ehedeman/expanse:expanse -- monarch-events  --use-latest-execution
```

Rollback Plan:

Differential Revision: D77389179


