### PR TITLE
Downgrade log on dropped children

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1515,10 +1515,11 @@ impl InstanceCell {
 
 impl Drop for InstanceState {
     fn drop(&mut self) {
-        if self.maybe_unlink_parent().is_some() {
-            tracing::error!(
-                "instance {} was dropped with parent still linked",
-                self.actor_id
+        if let Some(parent) = self.maybe_unlink_parent() {
+            tracing::debug!(
+                "instance {} was dropped with parent {} still linked",
+                self.actor_id,
+                parent.actor_id()
             );
         }
         if self.proc.inner.instances.remove(&self.actor_id).is_none() {


### PR DESCRIPTION
Summary:
On every cast a new child actor is created to listen to the cast response to prevent races, see D76086153

These children are ephemeral and dropped as soon as cast is over, leading to log spew P1859304760

We should not log an error if it is expected for child actors to be dropped while parent is still alive

Differential Revision: D77749480


