### PR TITLE
Add `CanSend` impls for reference types too

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1323,6 +1323,17 @@ impl cap::sealed::CanSend for Mailbox {
         MailboxSender::post(self, envelope, return_handle);
     }
 }
+impl cap::sealed::CanSend for &Mailbox {
+    fn post(&self, dest: PortId, headers: Attrs, data: Serialized) {
+        cap::sealed::CanSend::post(*self, dest, headers, data)
+    }
+}
+
+impl cap::sealed::CanOpenPort for &Mailbox {
+    fn mailbox(&self) -> &Mailbox {
+        self
+    }
+}
 
 impl cap::sealed::CanOpenPort for Mailbox {
     fn mailbox(&self) -> &Mailbox {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1195,7 +1195,19 @@ impl<A: Actor> cap::sealed::CanSend for Instance<A> {
     }
 }
 
+impl<A: Actor> cap::sealed::CanSend for &Instance<A> {
+    fn post(&self, dest: PortId, headers: Attrs, data: Serialized) {
+        (*self).post(dest, headers, data)
+    }
+}
+
 impl<A: Actor> cap::sealed::CanOpenPort for Instance<A> {
+    fn mailbox(&self) -> &Mailbox {
+        &self.mailbox
+    }
+}
+
+impl<A: Actor> cap::sealed::CanOpenPort for &Instance<A> {
     fn mailbox(&self) -> &Mailbox {
         &self.mailbox
     }
@@ -1234,7 +1246,19 @@ impl<A: Actor> cap::sealed::CanSend for Context<'_, A> {
     }
 }
 
+impl<A: Actor> cap::sealed::CanSend for &Context<'_, A> {
+    fn post(&self, dest: PortId, headers: Attrs, data: Serialized) {
+        <Instance<A> as cap::sealed::CanSend>::post(self, dest, headers, data)
+    }
+}
+
 impl<A: Actor> cap::sealed::CanOpenPort for Context<'_, A> {
+    fn mailbox(&self) -> &Mailbox {
+        <Instance<A> as cap::sealed::CanOpenPort>::mailbox(self)
+    }
+}
+
+impl<A: Actor> cap::sealed::CanOpenPort for &Context<'_, A> {
     fn mailbox(&self) -> &Mailbox {
         <Instance<A> as cap::sealed::CanOpenPort>::mailbox(self)
     }


### PR DESCRIPTION
Summary:
This makes it easier to use a generic to represent either `&Context<>` (borrowed),
`&Mailbox` (borrowed), or `Mailbox` (owned).

Differential Revision: D77868301


