### PR TITLE
Allow `PortReceiver` to be used as `Stream`

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -89,6 +89,7 @@ use dashmap::DashMap;
 use dashmap::DashSet;
 use dashmap::mapref::entry::Entry;
 use futures::Sink;
+use futures::Stream;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -1647,6 +1648,14 @@ impl<M> Drop for PortReceiver<M> {
         // error out if we have removed the receiver before serializing the port ref?
         // ("no longer live")?
         self.mailbox.inner.ports.remove(&self.port());
+    }
+}
+
+impl<M> Stream for PortReceiver<M> {
+    type Item = Result<M, MailboxError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        std::pin::pin!(self.recv()).poll(cx).map(Some)
     }
 }
 

--- a/hyperactor/src/reference.rs
+++ b/hyperactor/src/reference.rs
@@ -51,6 +51,7 @@ use crate::cap;
 use crate::data::Serialized;
 use crate::mailbox::MailboxSenderError;
 use crate::mailbox::MailboxSenderErrorKind;
+use crate::mailbox::PortSink;
 use crate::message::Bind;
 use crate::message::Bindings;
 use crate::message::Unbind;
@@ -892,6 +893,11 @@ impl<M: RemoteMessage> PortRef<M> {
     /// [`crate::actor::Instance`].
     pub fn send_serialized(&self, caps: &impl cap::CanSend, message: Serialized, headers: Attrs) {
         caps.post(self.port_id.clone(), headers, message);
+    }
+
+    /// Convert this port into a sink that can be used to send messages using the given capability.
+    pub fn into_sink<'a, C: cap::CanSend>(self, caps: &'a C) -> PortSink<'a, C, M> {
+        PortSink::new(caps, self)
     }
 }
 


### PR DESCRIPTION
Summary:
Adds a `Stream` impl for `PortReceiver` to make it usable with `StreamExt`
helpers.

Reviewed By: shayne-fletcher

Differential Revision: D77698392
