### PR TITLE
(2/n) get ready to optionally spin up state actor on the client

### DIFF
--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -35,6 +35,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::alloc::test_utils::MockAllocWrapper;
+use crate::log_source::LogSource;
 use crate::proc_mesh::mesh_agent::MeshAgent;
 
 /// Errors that occur during allocation operations.
@@ -217,6 +218,20 @@ pub trait Alloc {
 
     /// The channel transport used the procs in this alloc.
     fn transport(&self) -> ChannelTransport;
+
+    /// The log source for this alloc.
+    /// It allows remote processes to stream stdout and stderr back to the client.
+    /// A client can connect to the log source to obtain the streamed logs.
+    /// A log source is allocation specific. Each allocator can decide how to stream the logs back.
+    async fn log_source(&self) -> Result<LogSource, AllocatorError> {
+        // TODO: this should be implemented based on different allocators.
+        // Having this temporarily here so that the client can connect to the log source.
+        // But the client will not get anything.
+        // The following diffs will gradually implement this for different allocators.
+        LogSource::new_with_local_actor()
+            .await
+            .map_err(AllocatorError::from)
+    }
 
     /// Stop this alloc, shutting down all of its procs. A clean
     /// shutdown should result in Stop events from all allocs,

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -19,6 +19,7 @@ pub mod bootstrap;
 pub mod code_sync;
 pub mod comm;
 pub mod connect;
+pub mod log_source;
 pub mod mesh;
 pub mod mesh_selection;
 mod metrics;

--- a/hyperactor_mesh/src/log_source.rs
+++ b/hyperactor_mesh/src/log_source.rs
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::fmt;
+use std::str::FromStr;
+
+use hyperactor::ActorId;
+use hyperactor::ActorRef;
+use hyperactor::ProcId;
+use hyperactor::WorldId;
+use hyperactor::channel;
+use hyperactor::channel::ChannelAddr;
+use hyperactor::channel::ChannelTransport;
+use hyperactor::mailbox;
+use hyperactor::mailbox::BoxedMailboxSender;
+use hyperactor::mailbox::DialMailboxRouter;
+use hyperactor::mailbox::MailboxServer;
+use hyperactor::proc::Proc;
+use hyperactor_state::state_actor::StateActor;
+
+use crate::shortuuid::ShortUuid;
+
+/// The source of the log so that the remote process can stream stdout and stderr to.
+/// A log source is allocation specific. Each allocator can decide how to stream the logs back.
+/// It holds a reference or the lifecycle of a state actor that collects all the logs from processes.
+#[derive(Clone, Debug)]
+pub struct LogSource {
+    // Optionally hold the lifecycle of the state actor
+    _state_proc: Option<Proc>,
+    state_proc_addr: ChannelAddr,
+    state_actor: ActorRef<StateActor>,
+}
+
+#[derive(Clone, Debug)]
+pub struct StateServerInfo {
+    pub state_proc_addr: ChannelAddr,
+    pub state_actor_id: ActorId,
+}
+
+impl fmt::Display for StateServerInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{},{}", self.state_proc_addr, self.state_actor_id)
+    }
+}
+
+impl FromStr for StateServerInfo {
+    type Err = anyhow::Error;
+
+    fn from_str(state_server_info: &str) -> Result<Self, Self::Err> {
+        match state_server_info.split_once(",") {
+            Some((addr, id)) => {
+                let state_proc_addr: ChannelAddr = addr.parse()?;
+                let state_actor_id: ActorId = id.parse()?;
+                Ok(StateServerInfo {
+                    state_proc_addr,
+                    state_actor_id,
+                })
+            }
+            _ => Err(anyhow::anyhow!(
+                "unrecognized state server info: {state_server_info}"
+            )),
+        }
+    }
+}
+
+impl LogSource {
+    /// Spin up the state actor locally to receive the remote logs.
+    pub async fn new_with_local_actor() -> Result<Self, anyhow::Error> {
+        let router = DialMailboxRouter::new();
+        let state_proc_id = ProcId(WorldId(format!("local_state_{}", ShortUuid::generate())), 0);
+        let (state_proc_addr, state_rx) =
+            channel::serve(ChannelAddr::any(ChannelTransport::Unix)).await?;
+        let state_proc = Proc::new(
+            state_proc_id.clone(),
+            BoxedMailboxSender::new(router.clone()),
+        );
+        state_proc
+            .clone()
+            .serve(state_rx, mailbox::monitored_return_handle());
+        router.bind(state_proc_id.clone().into(), state_proc_addr.clone());
+        let state_actor = state_proc.spawn::<StateActor>("state", ()).await?.bind();
+
+        Ok(Self {
+            _state_proc: Some(state_proc),
+            state_proc_addr,
+            state_actor,
+        })
+    }
+
+    /// Connect to an existing state actor to receive the remote logs.
+    /// The lifecycle of the state actor should be maintained by the allocator who creates it.
+    pub fn new_with_remote_actor(state_proc_id: ActorId, state_proc_addr: ChannelAddr) -> Self {
+        Self {
+            _state_proc: None,
+            state_proc_addr,
+            state_actor: ActorRef::attest(state_proc_id),
+        }
+    }
+
+    pub fn server_info(&self) -> StateServerInfo {
+        StateServerInfo {
+            state_proc_addr: self.state_proc_addr.clone(),
+            state_actor_id: self.state_actor.actor_id().clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use std::time::Duration;
+
+    use hyperactor::channel;
+    use hyperactor::channel::ChannelAddr;
+    use hyperactor::clock::Clock;
+    use hyperactor::id;
+    use hyperactor_state::client::ClientActor;
+    use hyperactor_state::client::ClientActorParams;
+    use hyperactor_state::client::LogHandler;
+    use hyperactor_state::object::GenericStateObject;
+    use hyperactor_state::state_actor::StateMessageClient;
+    use hyperactor_state::test_utils::log_items;
+    use tokio::sync::mpsc::Sender;
+
+    use super::*;
+
+    #[test]
+    fn test_state_server_info_serialization() {
+        let addr = ChannelAddr::any(channel::ChannelTransport::Unix);
+        let actor_id: ActorId = id!(test_actor[42].actor[0]);
+
+        let info = StateServerInfo {
+            state_proc_addr: addr.clone(),
+            state_actor_id: actor_id.clone(),
+        };
+
+        // Test Display implementation
+        let serialized = format!("{}", info);
+        assert!(serialized.contains(","));
+
+        // Test FromStr implementation
+        let deserialized = StateServerInfo::from_str(&serialized).unwrap();
+        assert_eq!(
+            info.state_proc_addr.to_string(),
+            deserialized.state_proc_addr.to_string()
+        );
+        assert_eq!(
+            info.state_actor_id.to_string(),
+            deserialized.state_actor_id.to_string()
+        );
+    }
+
+    #[derive(Debug)]
+    struct MpscLogHandler {
+        sender: Sender<Vec<GenericStateObject>>,
+    }
+
+    impl LogHandler for MpscLogHandler {
+        fn handle_log(&self, logs: Vec<GenericStateObject>) -> anyhow::Result<()> {
+            let sender = self.sender.clone();
+            tokio::spawn(async move {
+                sender.send(logs).await.unwrap();
+            });
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_state_server_pushing_logs() {
+        // Spin up a new state actor
+        let log_source = LogSource::new_with_local_actor().await.unwrap();
+
+        // Setup the client and connect it to the state actor
+        let router = DialMailboxRouter::new();
+        let (client_proc_addr, client_rx) =
+            channel::serve(ChannelAddr::any(ChannelTransport::Unix))
+                .await
+                .unwrap();
+        let client_proc = Proc::new(id!(client[0]), BoxedMailboxSender::new(router.clone()));
+        client_proc
+            .clone()
+            .serve(client_rx, mailbox::monitored_return_handle());
+        router.bind(id!(client[0]).into(), client_proc_addr.clone());
+        router.bind(
+            log_source.server_info().state_actor_id.clone().into(),
+            log_source.server_info().state_proc_addr.clone(),
+        );
+        let client = client_proc.attach("client").unwrap();
+
+        // Spin up the client logging actor and subscribe to the state actor
+        let (sender, mut receiver) = tokio::sync::mpsc::channel::<Vec<GenericStateObject>>(20);
+        let log_handler = Box::new(MpscLogHandler { sender });
+        let params = ClientActorParams { log_handler };
+
+        let client_logging_actor: ActorRef<ClientActor> = client_proc
+            .spawn::<ClientActor>("logging_client", params)
+            .await
+            .unwrap()
+            .bind();
+        let state_actor_ref: ActorRef<StateActor> =
+            ActorRef::attest(log_source.server_info().state_actor_id.clone());
+        state_actor_ref
+            .subscribe_logs(
+                &client,
+                client_proc_addr.clone(),
+                client_logging_actor.clone(),
+            )
+            .await
+            .unwrap();
+
+        // Write some logs
+        state_actor_ref
+            .push_logs(&client, log_items(0, 10))
+            .await
+            .unwrap();
+
+        // Collect received messages with timeout
+        let fetched_logs = client_proc
+            .clock()
+            .timeout(Duration::from_secs(1), receiver.recv())
+            .await
+            .expect("timed out waiting for message")
+            .expect("channel closed unexpectedly");
+
+        // Verify we received all expected logs
+        assert_eq!(fetched_logs.len(), 10);
+        assert_eq!(fetched_logs, log_items(0, 10));
+    }
+}

--- a/hyperactor_state/src/client.rs
+++ b/hyperactor_state/src/client.rs
@@ -16,9 +16,73 @@ use hyperactor_macros::HandleClient;
 use hyperactor_macros::RefClient;
 use serde::Deserialize;
 use serde::Serialize;
-use tokio::sync::mpsc::Sender;
 
 use crate::object::GenericStateObject;
+use crate::object::Kind;
+use crate::object::LogSpec;
+use crate::object::LogState;
+use crate::object::Name;
+use crate::object::StateObject;
+
+pub trait LogHandler: Sync + Send + std::fmt::Debug + 'static {
+    // we cannot call it handle here as it conflicts with hyperactor macro
+    fn handle_log(&self, logs: Vec<GenericStateObject>) -> Result<()>;
+}
+
+/// A log handler that flushes GenericStateObject to stdout.
+#[derive(Debug)]
+pub struct StdlogHandler;
+
+impl LogHandler for StdlogHandler {
+    fn handle_log(&self, logs: Vec<GenericStateObject>) -> Result<()> {
+        for log in logs {
+            let metadata = log.metadata();
+            let deserialized_data: StateObject<LogSpec, LogState> = log.data().deserialized()?;
+
+            // Deserialize the message and process line by line with UTF-8
+            let message_lines = deserialize_message_lines(&deserialized_data.state.message)?;
+
+            // TODO: @lky D77377307 do not use raw string to distinguish between stdout and stderr
+            if metadata.kind != Kind::Log {
+                continue;
+            }
+            match &metadata.name {
+                Name::StdoutLog((hostname, pid)) => {
+                    for line in message_lines {
+                        // TODO: @lky hostname and pid should only be printed for non-aggregated logs. =
+                        // For aggregated logs, we should leave as is for better aggregation.
+                        println!("[{} {}] {}", hostname, pid, line);
+                    }
+                }
+                Name::StderrLog((hostname, pid)) => {
+                    for line in message_lines {
+                        eprintln!("[{} {}] {}", hostname, pid, line);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Deserialize a Serialized message and split it into UTF-8 lines
+fn deserialize_message_lines(
+    serialized_message: &hyperactor::data::Serialized,
+) -> Result<Vec<String>> {
+    // Try to deserialize as String first
+    if let Ok(message_str) = serialized_message.deserialized::<String>() {
+        return Ok(message_str.lines().map(|s| s.to_string()).collect());
+    }
+
+    // If that fails, try to deserialize as Vec<u8> and convert to UTF-8
+    if let Ok(message_bytes) = serialized_message.deserialized::<Vec<u8>>() {
+        let message_str = String::from_utf8(message_bytes)?;
+        return Ok(message_str.lines().map(|s| s.to_string()).collect());
+    }
+
+    // If both fail, return an error
+    anyhow::bail!("Failed to deserialize message as either String or Vec<u8>")
+}
 
 /// A client to interact with the state actor.
 #[derive(Debug)]
@@ -26,7 +90,8 @@ use crate::object::GenericStateObject;
     handlers = [ClientMessage],
 )]
 pub struct ClientActor {
-    sender: Sender<Vec<GenericStateObject>>,
+    // TODO: extend hyperactor macro to support a generic to avoid using Box here.
+    log_handler: Box<dyn LogHandler>,
 }
 
 /// Endpoints for the client actor.
@@ -37,15 +102,17 @@ pub enum ClientMessage {
 }
 
 pub struct ClientActorParams {
-    pub sender: Sender<Vec<GenericStateObject>>,
+    pub log_handler: Box<dyn LogHandler>,
 }
 
 #[async_trait]
 impl Actor for ClientActor {
     type Params = ClientActorParams;
 
-    async fn new(ClientActorParams { sender }: ClientActorParams) -> Result<Self, anyhow::Error> {
-        Ok(Self { sender })
+    async fn new(
+        ClientActorParams { log_handler }: ClientActorParams,
+    ) -> Result<Self, anyhow::Error> {
+        Ok(Self { log_handler })
     }
 }
 
@@ -57,7 +124,7 @@ impl ClientMessageHandler for ClientActor {
         _cx: &Context<Self>,
         logs: Vec<GenericStateObject>,
     ) -> Result<(), anyhow::Error> {
-        self.sender.send(logs).await?;
+        self.log_handler.handle_log(logs)?;
         Ok(())
     }
 }
@@ -69,18 +136,38 @@ mod tests {
     use hyperactor::ActorRef;
     use hyperactor::channel;
     use hyperactor::channel::ChannelAddr;
+    use hyperactor::clock::Clock;
+    use hyperactor::data::Serialized;
+    use tokio::sync::mpsc::Sender;
 
     use super::*;
     use crate::create_remote_client;
     use crate::test_utils::log_items;
     use crate::test_utils::spawn_actor;
 
+    /// A log handler that flushes GenericStateObject to a mpsc channel.
+    #[derive(Debug)]
+    struct MpscLogHandler {
+        sender: Sender<Vec<GenericStateObject>>,
+    }
+
+    impl LogHandler for MpscLogHandler {
+        fn handle_log(&self, logs: Vec<GenericStateObject>) -> Result<()> {
+            let sender = self.sender.clone();
+            tokio::spawn(async move {
+                sender.send(logs).await.unwrap();
+            });
+            Ok(())
+        }
+    }
+
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_client_basics() {
         let client_actor_addr = ChannelAddr::any(channel::ChannelTransport::Unix);
         let (sender, mut receiver) = tokio::sync::mpsc::channel::<Vec<GenericStateObject>>(10);
-        let params = ClientActorParams { sender };
+        let log_handler = Box::new(MpscLogHandler { sender });
+        let params = ClientActorParams { log_handler };
         let client_proc_id =
             hyperactor::reference::ProcId(hyperactor::WorldId("client_server".to_string()), 0);
         let (client_actor_addr, client_actor_handle, _client_mailbox) = spawn_actor::<ClientActor>(
@@ -102,7 +189,9 @@ mod tests {
             .unwrap();
 
         // Collect received messages with timeout
-        let fetched_logs = tokio::time::timeout(Duration::from_secs(1), receiver.recv())
+        let clock = hyperactor::clock::ClockKind::default();
+        let fetched_logs = clock
+            .timeout(Duration::from_secs(1), receiver.recv())
             .await
             .expect("timed out waiting for message")
             .expect("channel closed unexpectedly");
@@ -112,7 +201,53 @@ mod tests {
         assert_eq!(fetched_logs, log_items_0_10);
 
         // Now test that no extra message is waiting
-        let extra = tokio::time::timeout(Duration::from_millis(100), receiver.recv()).await;
+        let extra = clock
+            .timeout(Duration::from_millis(100), receiver.recv())
+            .await;
         assert!(extra.is_err(), "expected no more messages");
+    }
+
+    #[test]
+    fn test_deserialize_message_lines_string() {
+        // Test deserializing a String message with multiple lines
+        let message = "Line 1\nLine 2\nLine 3".to_string();
+        let serialized = Serialized::serialize_anon(&message).unwrap();
+
+        let result = deserialize_message_lines(&serialized).unwrap();
+
+        assert_eq!(result, vec!["Line 1", "Line 2", "Line 3"]);
+
+        // Test deserializing a Vec<u8> message with UTF-8 content
+        let message_bytes = "Hello\nWorld\nUTF-8 \u{1F980}".as_bytes().to_vec();
+        let serialized = Serialized::serialize_anon(&message_bytes).unwrap();
+
+        let result = deserialize_message_lines(&serialized).unwrap();
+
+        assert_eq!(result, vec!["Hello", "World", "UTF-8 \u{1F980}"]);
+
+        // Test deserializing a single line message
+        let message = "Single line message".to_string();
+        let serialized = Serialized::serialize_anon(&message).unwrap();
+
+        let result = deserialize_message_lines(&serialized).unwrap();
+
+        assert_eq!(result, vec!["Single line message"]);
+
+        // Test deserializing an empty lines
+        let message = "\n\n".to_string();
+        let serialized = Serialized::serialize_anon(&message).unwrap();
+
+        let result = deserialize_message_lines(&serialized).unwrap();
+
+        assert_eq!(result, vec!["", ""]);
+
+        // Test error handling for invalid UTF-8 bytes
+        let invalid_utf8_bytes = vec![0xFF, 0xFE, 0xFD]; // Invalid UTF-8 sequence
+        let serialized = Serialized::serialize_anon(&invalid_utf8_bytes).unwrap();
+
+        let result = deserialize_message_lines(&serialized);
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("invalid utf-8"));
     }
 }


### PR DESCRIPTION
Summary: create log_source object so that allocators can choose to spin up state actor colocated with the client or connect to a remote one.

Differential Revision: D77848229
