### PR TITLE
Expose more helpers on `ActorMesh`

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1323,6 +1323,17 @@ impl cap::sealed::CanSend for Mailbox {
         MailboxSender::post(self, envelope, return_handle);
     }
 }
+impl cap::sealed::CanSend for &Mailbox {
+    fn post(&self, dest: PortId, headers: Attrs, data: Serialized) {
+        cap::sealed::CanSend::post(*self, dest, headers, data)
+    }
+}
+
+impl cap::sealed::CanOpenPort for &Mailbox {
+    fn mailbox(&self) -> &Mailbox {
+        self
+    }
+}
 
 impl cap::sealed::CanOpenPort for Mailbox {
     fn mailbox(&self) -> &Mailbox {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1195,7 +1195,19 @@ impl<A: Actor> cap::sealed::CanSend for Instance<A> {
     }
 }
 
+impl<A: Actor> cap::sealed::CanSend for &Instance<A> {
+    fn post(&self, dest: PortId, headers: Attrs, data: Serialized) {
+        (*self).post(dest, headers, data)
+    }
+}
+
 impl<A: Actor> cap::sealed::CanOpenPort for Instance<A> {
+    fn mailbox(&self) -> &Mailbox {
+        &self.mailbox
+    }
+}
+
+impl<A: Actor> cap::sealed::CanOpenPort for &Instance<A> {
     fn mailbox(&self) -> &Mailbox {
         &self.mailbox
     }
@@ -1234,7 +1246,19 @@ impl<A: Actor> cap::sealed::CanSend for Context<'_, A> {
     }
 }
 
+impl<A: Actor> cap::sealed::CanSend for &Context<'_, A> {
+    fn post(&self, dest: PortId, headers: Attrs, data: Serialized) {
+        <Instance<A> as cap::sealed::CanSend>::post(self, dest, headers, data)
+    }
+}
+
 impl<A: Actor> cap::sealed::CanOpenPort for Context<'_, A> {
+    fn mailbox(&self) -> &Mailbox {
+        <Instance<A> as cap::sealed::CanOpenPort>::mailbox(self)
+    }
+}
+
+impl<A: Actor> cap::sealed::CanOpenPort for &Context<'_, A> {
     fn mailbox(&self) -> &Mailbox {
         <Instance<A> as cap::sealed::CanOpenPort>::mailbox(self)
     }

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -15,6 +15,8 @@ use hyperactor::Actor;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
 use hyperactor::Bind;
+use hyperactor::GangId;
+use hyperactor::GangRef;
 use hyperactor::Message;
 use hyperactor::Named;
 use hyperactor::PortHandle;
@@ -144,6 +146,13 @@ pub trait ActorMesh: Mesh {
 
     fn world_id(&self) -> &WorldId {
         self.proc_mesh().world_id()
+    }
+
+    /// Iterate over all `ActorRef<Self::Actor>` in this mesh.
+    fn iter_actor_refs(&self) -> impl Iterator<Item = ActorRef<Self::Actor>> {
+        let gang: GangRef<Self::Actor> =
+            GangId(self.proc_mesh().world_id().clone(), self.name().to_string()).into();
+        self.shape().slice().iter().map(move |rank| gang.rank(rank))
     }
 
     /// Get a serializeable reference to this mesh similar to ActorHandle::bind


### PR DESCRIPTION
Summary:
Expose some additional helper methods off `ActorMeshRef`.

In particular, `iter_actor_refs()` can be used by clients using `ActorConnection`s,
as these, by definition, need to be established point-to-point.

Reviewed By: mariusae

Differential Revision: D77880648


