### PR TITLE
mesh: streams are keyed on (ActorMeshId, Sender)

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -39,6 +39,8 @@ use hyperactor_mesh::comm::multicast::CastMessage;
 use hyperactor_mesh::comm::multicast::CastMessageEnvelope;
 use hyperactor_mesh::comm::multicast::DestinationPort;
 use hyperactor_mesh::comm::multicast::Uslice;
+use hyperactor_mesh::reference::ActorMeshId;
+use hyperactor_mesh::reference::ProcMeshId;
 use hyperactor_multiprocess::proc_actor::ProcActor;
 use hyperactor_multiprocess::proc_actor::spawn;
 use hyperactor_multiprocess::supervision::WorldSupervisionMessageClient;
@@ -422,7 +424,12 @@ impl ControllerMessageHandler for ControllerActor {
                 dsl::union(sel, slice_to_selection(slice))
             }),
         };
+
         let message = CastMessageEnvelope::from_serialized(
+            ActorMeshId(
+                ProcMeshId(self.worker_gang_ref.gang_id().world_id().to_string()),
+                self.worker_gang_ref.gang_id().name().to_string(),
+            ),
             cx.self_id().clone(),
             DestinationPort::new::<WorkerActor, WorkerMessage>(
                 // This is awkward, but goes away entirely with meshes.

--- a/hyperactor_mesh/src/mesh.rs
+++ b/hyperactor_mesh/src/mesh.rs
@@ -7,6 +7,7 @@
  */
 
 use async_trait::async_trait;
+use hyperactor::RemoteMessage;
 use ndslice::Range;
 use ndslice::Shape;
 use ndslice::ShapeError;
@@ -17,6 +18,9 @@ use ndslice::SliceIterator;
 pub trait Mesh {
     /// The type of the node contained in the mesh.
     type Node;
+
+    /// The type of identifiers for this mesh.
+    type Id: RemoteMessage;
 
     /// The type of a slice of this mesh. Slices should not outlive their
     /// parent mesh.
@@ -43,6 +47,9 @@ pub trait Mesh {
             slice_iter: self.shape().slice().iter(),
         }
     }
+
+    /// The global identifier for this mesh.
+    fn id(&self) -> Self::Id;
 }
 
 /// An iterator over the nodes of a mesh.

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -54,6 +54,7 @@ use crate::assign::Ranks;
 use crate::comm::CommActorMode;
 use crate::proc_mesh::mesh_agent::MeshAgent;
 use crate::proc_mesh::mesh_agent::MeshAgentMessageClient;
+use crate::reference::ProcMeshId;
 
 pub mod mesh_agent;
 
@@ -574,6 +575,7 @@ impl<D: Deref<Target = ProcMesh> + Send + Sync + 'static> SharedSpawnable for D 
 #[async_trait]
 impl Mesh for ProcMesh {
     type Node = ProcId;
+    type Id = ProcMeshId;
     type Sliced<'a> = SlicedProcMesh<'a>;
 
     fn shape(&self) -> &Shape {
@@ -590,6 +592,10 @@ impl Mesh for ProcMesh {
 
     fn get(&self, rank: usize) -> Option<ProcId> {
         Some(self.ranks[rank].0.clone())
+    }
+
+    fn id(&self) -> Self::Id {
+        ProcMeshId(self.world_id().name().to_string())
     }
 }
 
@@ -616,6 +622,7 @@ pub struct SlicedProcMesh<'a>(&'a ProcMesh, Shape);
 #[async_trait]
 impl Mesh for SlicedProcMesh<'_> {
     type Node = ProcId;
+    type Id = ProcMeshId;
     type Sliced<'b>
         = SlicedProcMesh<'b>
     where
@@ -635,6 +642,10 @@ impl Mesh for SlicedProcMesh<'_> {
 
     fn get(&self, _index: usize) -> Option<ProcId> {
         unimplemented!()
+    }
+
+    fn id(&self) -> Self::Id {
+        self.0.id()
     }
 }
 

--- a/hyperactor_mesh/src/reference.rs
+++ b/hyperactor_mesh/src/reference.rs
@@ -134,6 +134,7 @@ impl<A: RemoteActor> ActorMeshRef<A> {
     {
         actor_mesh_cast::<M, A>(
             caps,
+            self.mesh_id.clone(),
             self.shape(),
             self.proc_mesh_shape(),
             self.name(),


### PR DESCRIPTION
Summary:
This change aligns all of the stream keys along the comm actor delivery path. We formalize streams to be per-(ActorMeshId, Sender), and enforce this everywhere.

After this change, we can begin to simplify the comm actor delivery code.

with shayne-fletcher

Differential Revision: D77963903


