### PR TITLE
Move import out of ProcMesh.__del__

### DIFF
--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -8,6 +8,7 @@
 
 import os
 import sys
+import warnings
 from contextlib import AbstractContextManager
 
 from typing import (
@@ -275,8 +276,6 @@ class ProcMesh(MeshTrait):
     # Finalizer to check if the proc mesh was closed properly.
     def __del__(self) -> None:
         if not self._stopped:
-            import warnings
-
             warnings.warn(
                 f"unstopped ProcMesh {self!r}",
                 ResourceWarning,


### PR DESCRIPTION
Summary:
You cannot import a module during the Python runtime shutdown, which leads to an
error if any ProcMesh objects are being garbage collected without being stopped.
Move this import to the top level, it's not important to import it lazily.

Reviewed By: zdevito, colin2328

Differential Revision: D77973599


