### PR TITLE
local_proc_mesh with sim channels

### DIFF
--- a/controller/src/lib.rs
+++ b/controller/src/lib.rs
@@ -624,7 +624,6 @@ mod tests {
     use hyperactor::RefClient;
     use hyperactor::channel;
     use hyperactor::channel::ChannelTransport;
-    use hyperactor::channel::sim::SimAddr;
     use hyperactor::clock::Clock;
     use hyperactor::clock::RealClock;
     use hyperactor::data::Named;
@@ -1559,20 +1558,13 @@ mod tests {
     #[tokio::test]
     async fn test_sim_supervision_failure() {
         // Start system actor.
-        let system_addr = ChannelAddr::any(ChannelTransport::Unix);
-        let proxy_addr = ChannelAddr::any(ChannelTransport::Unix);
-        simnet::start(
-            ChannelAddr::any(ChannelTransport::Unix),
-            proxy_addr.clone(),
-            1000,
-        )
-        .unwrap();
+        simnet::start();
         simnet::simnet_handle()
             .unwrap()
             .set_training_script_state(simnet::TrainingScriptState::Waiting);
 
         let system_sim_addr =
-            ChannelAddr::Sim(SimAddr::new(system_addr, proxy_addr.clone()).unwrap());
+            ChannelAddr::any(ChannelTransport::Sim(Box::new(ChannelTransport::Unix)));
         // Set very long supervision_update_timeout
         let server_handle = System::serve(
             system_sim_addr.clone(),
@@ -1588,9 +1580,8 @@ mod tests {
         // Bootstrap the controller
         let controller_id = id!(controller[0].root);
         let proc_id = id!(world[0]);
-        let controller_proc_listen_addr = ChannelAddr::Sim(
-            SimAddr::new(ChannelAddr::any(ChannelTransport::Unix), proxy_addr).unwrap(),
-        );
+        let controller_proc_listen_addr =
+            ChannelAddr::any(ChannelTransport::Sim(Box::new(ChannelTransport::Unix)));
 
         let (_, actor_ref) = ControllerActor::bootstrap(
             controller_id.clone(),

--- a/hyperactor/src/clock.rs
+++ b/hyperactor/src/clock.rs
@@ -309,8 +309,7 @@ impl Clock for RealClock {
 
 #[cfg(test)]
 mod tests {
-    use crate::channel::ChannelAddr;
-    use crate::channel::ChannelTransport;
+
     use crate::clock::Clock;
     use crate::clock::SimClock;
     use crate::simnet;
@@ -341,12 +340,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_sim_timeout() {
-        simnet::start(
-            ChannelAddr::any(ChannelTransport::Unix),
-            ChannelAddr::any(ChannelTransport::Unix),
-            1000,
-        )
-        .unwrap();
+        simnet::start();
         let res = SimClock
             .timeout(tokio::time::Duration::from_secs(10), async {
                 SimClock.sleep(tokio::time::Duration::from_secs(5)).await;

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2360,7 +2360,6 @@ mod tests {
     use crate::channel::ChannelTransport;
     use crate::channel::dial;
     use crate::channel::serve;
-    use crate::channel::sim::AddressProxyPair;
     use crate::channel::sim::SimAddr;
     use crate::clock::Clock;
     use crate::clock::RealClock;
@@ -2561,23 +2560,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_sim_client_server() {
-        let proxy = ChannelAddr::any(channel::ChannelTransport::Unix);
-        simnet::start(
-            ChannelAddr::any(ChannelTransport::Unix),
-            proxy.clone(),
-            1000,
-        )
-        .unwrap();
-        let dst_addr =
-            SimAddr::new("local!1".parse::<ChannelAddr>().unwrap(), proxy.clone()).unwrap();
+        simnet::start();
+        let dst_addr = SimAddr::new("local!1".parse::<ChannelAddr>().unwrap()).unwrap();
         let src_to_dst = ChannelAddr::Sim(
             SimAddr::new_with_src(
-                AddressProxyPair {
-                    address: "local!0".parse::<ChannelAddr>().unwrap(),
-                    proxy: proxy.clone(),
-                },
+                "local!0".parse::<ChannelAddr>().unwrap(),
                 dst_addr.addr().clone(),
-                dst_addr.proxy().clone(),
             )
             .unwrap(),
         );

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -992,4 +992,10 @@ mod tests {
             buck_resources::get("monarch/hyperactor_mesh/bootstrap").unwrap()
         )));
     }
+
+    mod sim {
+        use crate::alloc::sim::SimAllocator;
+
+        actor_mesh_test_suite!(SimAllocator::new_and_start_simnet());
+    }
 }

--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -13,6 +13,7 @@ pub mod local;
 pub(crate) mod logtailer;
 pub mod process;
 pub mod remoteprocess;
+pub mod sim;
 
 use std::collections::HashMap;
 use std::fmt;

--- a/hyperactor_mesh/src/alloc/sim.rs
+++ b/hyperactor_mesh/src/alloc/sim.rs
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Support for allocating procs in the local process with simulated channels.
+
+#![allow(dead_code)] // until it is used outside of testing
+
+use async_trait::async_trait;
+use hyperactor::WorldId;
+use hyperactor::channel::ChannelAddr;
+use hyperactor::channel::ChannelTransport;
+use hyperactor::mailbox::MailboxServerHandle;
+use hyperactor::proc::Proc;
+use ndslice::Shape;
+
+use super::ProcStopReason;
+use crate::alloc::Alloc;
+use crate::alloc::AllocSpec;
+use crate::alloc::Allocator;
+use crate::alloc::AllocatorError;
+use crate::alloc::LocalAlloc;
+use crate::alloc::ProcState;
+use crate::log_source::LogSource;
+use crate::shortuuid::ShortUuid;
+
+/// An allocator that runs procs in the local process with network traffic going through simulated channels.
+/// Other than transport, the underlying implementation is an inner LocalAlloc.
+pub struct SimAllocator;
+
+#[async_trait]
+impl Allocator for SimAllocator {
+    type Alloc = SimAlloc;
+
+    async fn allocate(&mut self, spec: AllocSpec) -> Result<Self::Alloc, AllocatorError> {
+        Ok(SimAlloc::new(spec))
+    }
+}
+
+impl SimAllocator {
+    #[cfg(test)]
+    pub(crate) fn new_and_start_simnet() -> Self {
+        hyperactor::simnet::start();
+        Self
+    }
+}
+
+struct SimProc {
+    proc: Proc,
+    addr: ChannelAddr,
+    handle: MailboxServerHandle,
+}
+
+/// A simulated allocation. It is a collection of procs that are running in the local process.
+pub struct SimAlloc {
+    inner: LocalAlloc,
+}
+
+impl SimAlloc {
+    fn new(spec: AllocSpec) -> Self {
+        Self {
+            inner: LocalAlloc::new_with_transport(
+                spec,
+                ChannelTransport::Sim(Box::new(ChannelTransport::Unix)),
+            ),
+        }
+    }
+    /// A chaos monkey that can be used to stop procs at random.
+    pub(crate) fn chaos_monkey(&self) -> impl Fn(usize, ProcStopReason) + 'static {
+        self.inner.chaos_monkey()
+    }
+
+    /// A function to shut down the alloc for testing purposes.
+    pub(crate) fn stopper(&self) -> impl Fn() + 'static {
+        self.inner.stopper()
+    }
+
+    pub(crate) fn name(&self) -> &ShortUuid {
+        self.inner.name()
+    }
+
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+}
+
+#[async_trait]
+impl Alloc for SimAlloc {
+    async fn next(&mut self) -> Option<ProcState> {
+        self.inner.next().await
+    }
+
+    fn shape(&self) -> &Shape {
+        self.inner.shape()
+    }
+
+    fn world_id(&self) -> &WorldId {
+        self.inner.world_id()
+    }
+
+    fn transport(&self) -> ChannelTransport {
+        self.inner.transport()
+    }
+
+    async fn stop(&mut self) -> Result<(), AllocatorError> {
+        self.inner.stop().await
+    }
+
+    async fn log_source(&self) -> Result<LogSource, AllocatorError> {
+        self.inner.log_source().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_allocator_basic() {
+        hyperactor::simnet::start();
+        crate::alloc::testing::test_allocator_basic(SimAllocator).await;
+    }
+}

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -38,7 +38,6 @@ use hyperactor::RefClient;
 use hyperactor::WorldId;
 use hyperactor::actor::Handler;
 use hyperactor::channel::ChannelAddr;
-use hyperactor::channel::sim::AddressProxyPair;
 use hyperactor::channel::sim::SimAddr;
 use hyperactor::clock::Clock;
 use hyperactor::clock::ClockKind;
@@ -762,13 +761,9 @@ impl ReportingRouter {
                 ChannelAddr::Sim(
                     SimAddr::new_with_src(
                         // source is the sender
-                        AddressProxyPair {
-                            address: sender_sim_addr.addr().clone(),
-                            proxy: sender_sim_addr.proxy().clone(),
-                        },
+                        sender_sim_addr.addr().clone(),
                         // dest remains unchanged
                         dest_sim_addr.addr().clone(),
-                        dest_sim_addr.proxy().clone(),
                     )
                     .unwrap(),
                 )
@@ -2800,19 +2795,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_sim_address() {
-        let proxy = ChannelAddr::any(ChannelTransport::Unix);
-        simnet::start(
-            ChannelAddr::any(ChannelTransport::Unix),
-            proxy.clone(),
-            1000,
-        )
-        .unwrap();
+        simnet::start();
 
         let src_id = id!(proc[0].actor);
-        let src_addr =
-            ChannelAddr::Sim(SimAddr::new("unix!@src".parse().unwrap(), proxy.clone()).unwrap());
-        let dst_addr =
-            ChannelAddr::Sim(SimAddr::new("unix!@dst".parse().unwrap(), proxy.clone()).unwrap());
+        let src_addr = ChannelAddr::Sim(SimAddr::new("unix!@src".parse().unwrap()).unwrap());
+        let dst_addr = ChannelAddr::Sim(SimAddr::new("unix!@dst".parse().unwrap()).unwrap());
         let (_, mut rx) = channel::serve::<MessageEnvelope>(src_addr.clone())
             .await
             .unwrap();
@@ -2844,7 +2831,7 @@ mod tests {
             panic!("Expected sim address");
         };
 
-        assert_eq!(addr.src().clone().unwrap().address.to_string(), "unix!@src");
+        assert_eq!(addr.src().clone().unwrap().to_string(), "unix!@src");
         assert_eq!(addr.addr().to_string(), "unix!@dst");
     }
 }

--- a/monarch_extension/src/simulation_tools.rs
+++ b/monarch_extension/src/simulation_tools.rs
@@ -6,24 +6,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use hyperactor::channel::ChannelAddr;
-use hyperactor::channel::ChannelTransport;
 use hyperactor::clock::Clock;
 use hyperactor::clock::SimClock;
 use hyperactor::simnet;
-use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 
 #[pyfunction]
 #[pyo3(name = "start_event_loop")]
 pub fn start_simnet_event_loop(py: Python) -> PyResult<Bound<'_, PyAny>> {
     pyo3_async_runtimes::tokio::future_into_py(py, async move {
-        simnet::start(
-            ChannelAddr::any(ChannelTransport::Unix),
-            ChannelAddr::any(ChannelTransport::Unix),
-            1000,
-        )
-        .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
+        simnet::start();
         Ok(())
     })
 }

--- a/monarch_hyperactor/src/channel.rs
+++ b/monarch_hyperactor/src/channel.rs
@@ -25,7 +25,7 @@ pub enum PyChannelTransport {
     MetaTls,
     Local,
     Unix,
-    // Sim(/*proxy address:*/ ChannelAddr), TODO kiuk@ add support
+    // Sim(/*transport:*/ ChannelTransport), TODO kiuk@ add support
 }
 
 #[pyclass(
@@ -131,9 +131,7 @@ mod tests {
 
     #[test]
     fn test_channel_unsupported_transport() -> PyResult<()> {
-        let sim_addr = ChannelAddr::any(ChannelTransport::Sim(ChannelAddr::any(
-            ChannelTransport::Unix,
-        )));
+        let sim_addr = ChannelAddr::any(ChannelTransport::Sim(Box::new(ChannelTransport::Unix)));
         let addr = PyChannelAddr { inner: sim_addr };
 
         assert!(addr.get_port().is_err());

--- a/monarch_simulator/Cargo.toml
+++ b/monarch_simulator/Cargo.toml
@@ -29,5 +29,4 @@ torch-sys-cuda = { version = "0.0.0", path = "../torch-sys-cuda" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]
-rand = { version = "0.8", features = ["small_rng"] }
 tracing-test = { version = "0.2.3", features = ["no-env-filter"] }

--- a/monarch_simulator/src/bootstrap.rs
+++ b/monarch_simulator/src/bootstrap.rs
@@ -18,7 +18,6 @@ use hyperactor::ActorRef;
 use hyperactor::ProcId;
 use hyperactor::WorldId;
 use hyperactor::channel::ChannelAddr;
-use hyperactor::channel::sim::AddressProxyPair;
 use hyperactor::channel::sim::SimAddr;
 use hyperactor_multiprocess::System;
 use hyperactor_multiprocess::proc_actor::ProcActor;
@@ -62,15 +61,7 @@ pub async fn spawn_controller(
         panic!("bootstrap_addr must be a SimAddr");
     };
     let bootstrap_addr = ChannelAddr::Sim(
-        SimAddr::new_with_src(
-            AddressProxyPair {
-                address: listen_addr.clone(),
-                proxy: bootstrap_addr.proxy().clone(),
-            },
-            bootstrap_addr.addr().clone(),
-            bootstrap_addr.proxy().clone(),
-        )
-        .unwrap(),
+        SimAddr::new_with_src(listen_addr.clone(), bootstrap_addr.addr().clone()).unwrap(),
     );
     tracing::info!(
         "controller listen addr: {}, bootstrap addr: {}",
@@ -121,15 +112,7 @@ pub async fn spawn_sim_worker(
         panic!("bootstrap_addr must be a SimAddr");
     };
     let bootstrap_addr = ChannelAddr::Sim(
-        SimAddr::new_with_src(
-            AddressProxyPair {
-                address: listen_addr.clone(),
-                proxy: bootstrap_addr.proxy().clone(),
-            },
-            bootstrap_addr.addr().clone(),
-            bootstrap_addr.proxy().clone(),
-        )
-        .unwrap(),
+        SimAddr::new_with_src(listen_addr.clone(), bootstrap_addr.addr().clone()).unwrap(),
     );
     tracing::info!(
         "worker {} listen addr: {}, bootstrap addr: {}",

--- a/monarch_simulator/src/simulator.rs
+++ b/monarch_simulator/src/simulator.rs
@@ -116,35 +116,14 @@ mod tests {
     use hyperactor::ProcId;
     use hyperactor::WorldId;
     use hyperactor::channel::ChannelAddr;
-    use hyperactor::channel::ChannelTransport;
     use hyperactor::simnet;
-    use rand::Rng;
-    use rand::distributions::Alphanumeric;
-
-    #[cfg(target_os = "linux")]
-    fn random_str() -> String {
-        rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(24)
-            .map(char::from)
-            .collect::<String>()
-    }
 
     #[tracing_test::traced_test]
     #[tokio::test]
     async fn test_spawn_and_kill_mesh() {
-        let proxy = format!("unix!@{}", random_str());
+        simnet::start();
 
-        simnet::start(
-            ChannelAddr::any(ChannelTransport::Unix),
-            proxy.parse().unwrap(),
-            1000,
-        )
-        .unwrap();
-
-        let system_addr = format!("sim!unix!@system,{}", &proxy)
-            .parse::<ChannelAddr>()
-            .unwrap();
+        let system_addr = "sim!unix!@system".parse::<ChannelAddr>().unwrap();
         let mut simulator = super::TensorEngineSimulator::new(system_addr.clone())
             .await
             .unwrap();

--- a/monarch_simulator/src/worker.rs
+++ b/monarch_simulator/src/worker.rs
@@ -753,8 +753,6 @@ mod tests {
 
     use anyhow::Result;
     use futures::future::try_join_all;
-    use hyperactor::channel::ChannelAddr;
-    use hyperactor::channel::ChannelTransport;
     use hyperactor::id;
     use hyperactor::proc::Proc;
     use hyperactor::simnet;
@@ -808,12 +806,7 @@ mod tests {
 
     #[tokio::test]
     async fn worker_reduce() -> Result<()> {
-        simnet::start(
-            "local!0".parse::<ChannelAddr>().unwrap(),
-            ChannelAddr::any(ChannelTransport::Unix),
-            1000,
-        )
-        .unwrap();
+        simnet::start();
         let proc = Proc::local();
         //let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller")?;
         let client = proc.attach("client")?;

--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -116,6 +116,8 @@ _public_api = {
     "timer": ("monarch.timer", "timer"),
     "ProcessAllocator": ("monarch._src.actor.allocator", "ProcessAllocator"),
     "LocalAllocator": ("monarch._src.actor.allocator", "LocalAllocator"),
+    "SimAllocator": ("monarch._src_actor.allocator", "SimAllocator"),
+    "ActorFuture": ("monarch.future", "ActorFuture"),
     "builtins": ("monarch.builtins", "builtins"),
 }
 
@@ -184,6 +186,8 @@ __all__ = [
     "timer",
     "ProcessAllocator",
     "LocalAllocator",
+    "SimAllocator",
+    "ActorFuture",
     "builtins",
 ]
 assert sorted(__all__) == sorted(_public_api)

--- a/python/monarch/_rust_bindings/monarch_hyperactor/alloc.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/alloc.pyi
@@ -100,6 +100,26 @@ class LocalAllocatorBase:
         """
         ...
 
+class SimAllocatorBase:
+    async def allocate_nonblocking(self, spec: AllocSpec) -> Alloc:
+        """
+        Allocate a process according to the provided spec.
+
+        Arguments:
+        - `spec`: The spec to allocate according to.
+        """
+        ...
+
+    def allocate_blocking(self, spec: AllocSpec) -> Alloc:
+        """
+        Allocate a process according to the provided spec, blocking until an
+        alloc is returned.
+
+        Arguments:
+        - `spec`: The spec to allocate according to.
+        """
+        ...
+
 class RemoteAllocatorBase:
     def __new__(
         cls,

--- a/python/monarch/_src/actor/allocator.py
+++ b/python/monarch/_src/actor/allocator.py
@@ -16,6 +16,7 @@ from monarch._rust_bindings.monarch_hyperactor.alloc import (  # @manual=//monar
     LocalAllocatorBase,
     ProcessAllocatorBase,
     RemoteAllocatorBase,
+    SimAllocatorBase,
 )
 
 from monarch._src.actor.future import Future
@@ -51,6 +52,28 @@ class ProcessAllocator(ProcessAllocatorBase):
 class LocalAllocator(LocalAllocatorBase):
     """
     An allocator that allocates by spawning actors into the current process.
+    """
+
+    def allocate(self, spec: AllocSpec) -> Future[Alloc]:
+        """
+        Allocate a process according to the provided spec.
+
+        Arguments:
+        - `spec`: The spec to allocate according to.
+
+        Returns:
+        - A future that will be fulfilled when the requested allocation is fulfilled.
+        """
+        return Future(
+            lambda: self.allocate_nonblocking(spec),
+            lambda: self.allocate_blocking(spec),
+        )
+
+
+@final
+class SimAllocator(SimAllocatorBase):
+    """
+    An allocator that allocates by spawning actors into the current process using simulated channels for transport
     """
 
     def allocate(self, spec: AllocSpec) -> Future[Alloc]:

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -28,8 +28,8 @@ from monarch._src.actor.proc_mesh import (
     local_proc_mesh,
     proc_mesh,
     ProcMesh,
+    sim_proc_mesh,
 )
-
 
 __all__ = [
     "Accumulator",
@@ -47,6 +47,7 @@ __all__ = [
     "ProcMesh",
     "port",
     "send",
+    "sim_proc_mesh",
     "ValueMesh",
     "debug_client",
 ]

--- a/python/monarch/sim_mesh.py
+++ b/python/monarch/sim_mesh.py
@@ -58,9 +58,7 @@ from monarch.rust_backend_mesh import MeshWorld
 logger: logging.Logger = logging.getLogger(__name__)
 
 
-def sim_mesh(
-    n_meshes: int, hosts: int, gpus_per_host: int, proxy_addr: Optional[str] = None
-) -> List[DeviceMesh]:
+def sim_mesh(n_meshes: int, hosts: int, gpus_per_host: int) -> List[DeviceMesh]:
     """
     Creates a single simulated device mesh with the given number of per host.
 
@@ -185,7 +183,6 @@ class Bootstrap:
         Bootstraps a SimMesh.
         Args:
             num_meshes: int - number of meshes to create.
-            proxy_addr: Option[str] - the proxy address of the simulation process
             mesh_world_state: a state of the meshes. Keys are the MeshWorld and values are boolean indicating if this mesh is active.
         """
         # do a fake call to instantiate ThreadPoolExecutor so we don't block GIL later
@@ -196,13 +193,9 @@ class Bootstrap:
 
         self._mesh_world_state: Dict[MeshWorld, Optional[DeviceMesh]] = mesh_world_state
 
-        proxy_addr = f"unix!@{_random_id()}-proxy"
-        self.bootstrap_addr: str = f"sim!unix!@system,{proxy_addr}"
-        client_proxy_addr = f"unix!@{_random_id()}-proxy"
-        self.client_listen_addr = f"sim!unix!@client,{client_proxy_addr}"
-        self.client_bootstrap_addr = (
-            f"sim!unix!@client,{client_proxy_addr},unix!@system,{proxy_addr}"
-        )
+        self.bootstrap_addr: str = "sim!unix!@system"
+        self.client_listen_addr = "sim!unix!@client"
+        self.client_bootstrap_addr = "sim!unix!@client,unix!@system"
 
         self._simulator_client = SimulatorClient(self.bootstrap_addr, world_size)
         for i in range(num_meshes):

--- a/python/tests/test_sim_backend.py
+++ b/python/tests/test_sim_backend.py
@@ -24,11 +24,8 @@ def local_sim_mesh(
     # TODO: support multiple gpus in a mesh.
     gpu_per_host: int = 1,
     activate: bool = True,
-    proxy_addr: Optional[str] = None,
 ) -> Generator[DeviceMesh, None, None]:
-    dms = sim_mesh(
-        n_meshes=1, hosts=hosts, gpus_per_host=gpu_per_host, proxy_addr=proxy_addr
-    )
+    dms = sim_mesh(n_meshes=1, hosts=hosts, gpus_per_host=gpu_per_host)
     dm = dms[0]
     try:
         if activate:


### PR DESCRIPTION
Summary:
We want to instantiate local_proc_meshes that use ChannelTransport::SIm instead of ChannelTranport::Local so that the simulator can intercept and control the delivery of messages

Rollback Plan:

Differential Revision: D77941640
