### PR TITLE
wip

### DIFF
--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -290,7 +290,17 @@ pub enum AssignRankMessage {
 }
 
 #[async_trait]
-#[forward(WorkerMessage)]
+impl Handler<WorkerMessage> for WorkerActor {
+    async fn handle(
+        &mut self,
+        cx: &hyperactor::Context<Self>,
+        message: WorkerMessage,
+    ) -> anyhow::Result<()> {
+        <Self as WorkerMessageHandler>::handle(self, cx, message).await
+    }
+}
+
+#[async_trait]
 impl WorkerMessageHandler for WorkerActor {
     async fn backend_network_init(
         &mut self,


### PR DESCRIPTION
Summary:
- in D77963903, routing was updated to use the `(ActorMeshId, ActorId)` pair as the stream key for sequence number tracking. this change allows different sub-slices of a mesh to safely share a common stream identity as long as they belong to the same logical `ActorMeshId`, avoiding issues like message reordering or duplication due to slice mismatch

Rollback Plan:

Differential Revision: D77953855


