### PR TITLE
: actor_mesh: remove redundant params

### DIFF
--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -62,19 +62,23 @@ pub struct CastMessageEnvelope {
 
 impl CastMessageEnvelope {
     /// Create a new CastMessageEnvelope.
-    pub fn new<T: Castable + Serialize + Named>(
+    pub fn new<A, M>(
         actor_mesh_id: ActorMeshId,
         sender: ActorId,
-        dest_port: DestinationPort,
         shape: Shape,
-        message: T,
+        message: M,
         reducer_typehash: Option<u64>,
-    ) -> Result<Self, anyhow::Error> {
+    ) -> Result<Self, anyhow::Error>
+    where
+        A: RemoteActor + RemoteHandles<IndexedErasedUnbound<M>>,
+        M: Castable + RemoteMessage,
+    {
         let data = ErasedUnbound::try_from_message(message)?;
+        let actor_name = actor_mesh_id.1.to_string();
         Ok(Self {
             actor_mesh_id,
             sender,
-            dest_port,
+            dest_port: DestinationPort::new::<A, M>(actor_name),
             data,
             reducer_typehash,
             shape,

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -290,7 +290,17 @@ pub enum AssignRankMessage {
 }
 
 #[async_trait]
-#[forward(WorkerMessage)]
+impl Handler<WorkerMessage> for WorkerActor {
+    async fn handle(
+        &mut self,
+        cx: &hyperactor::Context<Self>,
+        message: WorkerMessage,
+    ) -> anyhow::Result<()> {
+        <Self as WorkerMessageHandler>::handle(self, cx, message).await
+    }
+}
+
+#[async_trait]
 impl WorkerMessageHandler for WorkerActor {
     async fn backend_network_init(
         &mut self,


### PR DESCRIPTION
Summary:
- remove the `DestinationPort` arg from `CastMessageEnvelope::new` since it can be calculated from the other arguments
- remove now unnecessary arguments from the utility `actor_mesh::actor_mesh_cast` (proc mesh shape and actor name)
- generally make the handling of generics consistent in these interfaces consistent

Differential Revision: D78030552


