### PR TITLE
update tracing-glog

### DIFF
--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -23,7 +23,7 @@ tokio = { version = "1.45.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-appender = "0.2.3"
 tracing-core = { version = "0.1.33", features = ["valuable"] }
-tracing-glog = { version = "0.4.0", features = ["ansi", "tracing-log"] }
+tracing-glog = { version = "0.4.1", features = ["ansi", "tracing-log"] }
 tracing-subscriber = { version = "0.3.19", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
 
 [features]


### PR DESCRIPTION
Summary: markbt wrote a patch to `tracing-glog` to adjust the formatting; I merged and released it as 0.4.1: https://github.com/davidbarsky/tracing-glog/releases/tag/v0.4.1.

Reviewed By: markbt

Differential Revision: D78103353
