### PR TITLE
Split Actor logs in their own files

### DIFF
--- a/hyperactor/src/init.rs
+++ b/hyperactor/src/init.rs
@@ -31,12 +31,27 @@ pub(crate) fn get_runtime() -> tokio::runtime::Handle {
 /// - Initialize logging defaults.
 /// - Store the provided tokio runtime handle for use by the hyperactor system.
 pub fn initialize(handle: tokio::runtime::Handle) {
+    initialize_with_log_prefix(handle, Option::None);
+}
+
+/// Initialize the Hyperactor runtime. Specifically:
+/// - Set up panic handling, so that we get consistent panic stack traces in Actors.
+/// - Initialize logging defaults.
+/// - Store the provided tokio runtime handle for use by the hyperactor system.
+/// - Set the env var whose value should be used to prefix log messages.
+pub fn initialize_with_log_prefix(
+    handle: tokio::runtime::Handle,
+    env_var_log_prefix: Option<String>,
+) {
     RUNTIME
         .set(handle)
         .expect("hyperactor::initialize must only be called once");
 
     panic_handler::set_panic_hook();
-    hyperactor_telemetry::initialize_logging(ClockKind::default());
+    hyperactor_telemetry::initialize_logging_with_log_prefix(
+        ClockKind::default(),
+        env_var_log_prefix,
+    );
 }
 
 /// Initialize the Hyperactor runtime using the current tokio runtime handle.

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -137,6 +137,8 @@ pub use hyperactor_telemetry::kv_pairs;
 pub use init::initialize;
 #[doc(inline)]
 pub use init::initialize_with_current_runtime;
+#[doc(inline)]
+pub use init::initialize_with_log_prefix;
 // Re-exported to make this available to callers of the `register!` macro.
 #[doc(hidden)]
 pub use inventory::submit;

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -26,8 +26,8 @@ use signal_hook::consts::signal::SIGTERM;
 
 use crate::proc_mesh::mesh_agent::MeshAgent;
 
-pub(crate) const BOOTSTRAP_ADDR_ENV: &str = "HYPERACTOR_MESH_BOOTSTRAP_ADDR";
-pub(crate) const BOOTSTRAP_INDEX_ENV: &str = "HYPERACTOR_MESH_INDEX";
+pub const BOOTSTRAP_ADDR_ENV: &str = "HYPERACTOR_MESH_BOOTSTRAP_ADDR";
+pub const BOOTSTRAP_INDEX_ENV: &str = "HYPERACTOR_MESH_INDEX";
 /// A channel used by each process to receive its own stdout and stderr
 /// Because stdout and stderr can only be obtained by the parent process,
 /// they need to be streamed back to the process.

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -25,6 +25,7 @@ tracing-appender = "0.2.3"
 tracing-core = { version = "0.1.33", features = ["valuable"] }
 tracing-glog = { version = "0.4.1", features = ["ansi", "tracing-log"] }
 tracing-subscriber = { version = "0.3.19", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
+whoami = "1.5"
 
 [features]
 default = []

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -67,7 +67,10 @@ fn get_or_add_new_module<'py>(
 pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
     monarch_hyperactor::runtime::initialize(module.py())?;
     let runtime = monarch_hyperactor::runtime::get_tokio_runtime();
-    ::hyperactor::initialize(runtime.handle().clone());
+    ::hyperactor::initialize_with_log_prefix(
+        runtime.handle().clone(),
+        Some(::hyperactor_mesh::bootstrap::BOOTSTRAP_INDEX_ENV.to_string()),
+    );
 
     monarch_hyperactor::shape::register_python_bindings(&get_or_add_new_module(
         module,


### PR DESCRIPTION
Summary:
- Each actor type will create a new file suffixed with the actor name
- Each log will contain the proc and rank id of the actor. This will simplify filtering to logs of a single actor
- Logs not coming from an actor will be dumped in a common file suffixed 'monarch'

TODO:
- Support Python Actors
- Support multiple configurable streams for Local

Differential Revision: D78101221


