### PR TITLE
fix pid in log_writer

### DIFF
--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -174,6 +174,7 @@ impl Child {
             match hyperactor_state::log_writer::create_log_writers(
                 state_actor_addr,
                 state_actor_ref,
+                process.id().unwrap_or(0),
             ) {
                 Ok((stdout_writer, stderr_writer)) => {
                     stdout_tee = stdout_writer;

--- a/hyperactor_state/src/object.rs
+++ b/hyperactor_state/src/object.rs
@@ -21,13 +21,14 @@ pub enum Name {
     StderrLog((String, u32)),
 }
 
-impl From<OutputTarget> for Name {
-    fn from(target: OutputTarget) -> Self {
+impl Name {
+    /// Creates a new Name from an OutputTarget and a specific process ID.
+    /// This allows passing in a PID from outside instead of using the current process ID.
+    pub fn from_target_with_pid(target: OutputTarget, pid: u32) -> Self {
         let hostname = hostname::get()
             .unwrap_or_else(|_| "unknown_host".into())
             .into_string()
             .unwrap_or("unknown_host".to_string());
-        let pid = std::process::id();
 
         match target {
             OutputTarget::Stdout => Name::StdoutLog((hostname, pid)),


### PR DESCRIPTION
Summary:
Previously process ID was derived wrong by using the process ID of the current process. That is wrong because the log_writer is spawned on the parent process.
This diff corrects it by attaching the Child process's pid to the log writer so this pid can be used directly in generating the Log Object Name.

Reviewed By: highker

Differential Revision: D78105348


