### PR TITLE
: selection: routing: promote terminals true and false (not just true)

### DIFF
--- a/ndslice/src/selection.rs
+++ b/ndslice/src/selection.rs
@@ -892,26 +892,28 @@ impl Selection {
         }
     }
 
-    // "Pads out" a selection so that if `Selection::True` appears before
-    // the final dimension, it becomes All(All(...(True))), enough to fill
-    // the remaining dimensions.
-    pub(crate) fn promote_terminal_true(self, dim: usize, max_dim: usize) -> Selection {
+    /// Pads out a terminal selection (e.g., `True`, `False`) with
+    /// `All(...)` to reach `max_dim` dimensions.
+    pub(crate) fn promote_terminal(self, dim: usize, max_dim: usize) -> Selection {
         use crate::selection::dsl::*;
 
         match self {
             Selection::True if dim < max_dim => all(true_()),
-            Selection::All(inner) => all(inner.promote_terminal_true(dim + 1, max_dim)),
-            Selection::Range(r, inner) => range(r, inner.promote_terminal_true(dim + 1, max_dim)),
+            Selection::False if dim < max_dim => all(false_()),
+
+            Selection::All(inner) => all(inner.promote_terminal(dim + 1, max_dim)),
+            Selection::Range(r, inner) => range(r, inner.promote_terminal(dim + 1, max_dim)),
             Selection::Intersection(a, b) => intersection(
-                a.promote_terminal_true(dim, max_dim),
-                b.promote_terminal_true(dim, max_dim),
+                a.promote_terminal(dim, max_dim),
+                b.promote_terminal(dim, max_dim),
             ),
             Selection::Union(a, b) => union(
-                a.promote_terminal_true(dim, max_dim),
-                b.promote_terminal_true(dim, max_dim),
+                a.promote_terminal(dim, max_dim),
+                b.promote_terminal(dim, max_dim),
             ),
-            Selection::First(inner) => first(inner.promote_terminal_true(dim + 1, max_dim)),
-            Selection::Any(inner) => any(inner.promote_terminal_true(dim + 1, max_dim)),
+            Selection::First(inner) => first(inner.promote_terminal(dim + 1, max_dim)),
+            Selection::Any(inner) => any(inner.promote_terminal(dim + 1, max_dim)),
+
             other => other,
         }
     }

--- a/ndslice/src/selection/routing.rs
+++ b/ndslice/src/selection/routing.rs
@@ -409,7 +409,7 @@ impl RoutingFrame {
         let selection = self
             .selection
             .clone()
-            .promote_terminal_true(self.dim, self.slice.num_dim());
+            .promote_terminal(self.dim, self.slice.num_dim());
         match &selection {
             Selection::True => ControlFlow::Continue(()),
             Selection::False => ControlFlow::Continue(()),
@@ -1644,7 +1644,7 @@ mod tests {
         assert!(step.deliver_here());
         assert_eq!(step.slice.location(&step.here).unwrap(), 42);
 
-        let selection = all(false_());
+        let selection = false_();
         let frame = RoutingFrame::root(selection, slice);
 
         let mut steps = vec![];


### PR DESCRIPTION
Summary: it never came up before due to there being no surface syntax for `False` but terminal promotion should by symmetry be the same for `False` as exists for `True`.

Differential Revision: D78169907


