### PR TITLE
Fix a Bind/Unbind macro bug

### DIFF
--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -1600,7 +1600,7 @@ where
 
             Ok(match &variant.fields {
                 Fields::Named(_) => {
-                    quote! { Self::#name { #(#field_accessors),*, } => { #(#items)* } }
+                    quote! { Self::#name { #(#field_accessors),* } => { #(#items)* } }
                 }
                 Fields::Unnamed(_) => {
                     quote! { Self::#name( #(#field_accessors),* ) => { #(#items)* } }

--- a/hyperactor_macros/tests/castable.rs
+++ b/hyperactor_macros/tests/castable.rs
@@ -17,6 +17,15 @@ use hyperactor::message::Unbind;
 use serde::Deserialize;
 use serde::Serialize;
 
+#[derive(Bind, Unbind)]
+struct MyUnitStruct;
+
+#[derive(Bind, Unbind)]
+struct EmptyNamedStruct {}
+
+#[derive(Bind, Unbind)]
+struct EmptyUnamedStruct();
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Named)]
 struct MyReply(String);
 
@@ -46,6 +55,8 @@ struct MyGenericStruct<'a, A: Bind + Unbind, B>(#[binding(include)] A, &'a B, A)
 #[derive(Clone, Debug, PartialEq, Bind, Unbind)]
 enum MyEnum {
     Unit,
+    EmptyStruct {},
+    EmptyTuple(),
     NoopTuple(u64, bool),
     NoopStruct {
         field0: u64,
@@ -72,6 +83,8 @@ enum MyEnum {
 #[derive(Clone, Debug, PartialEq, Bind, Unbind)]
 enum MyGenericEnum<'a, A: Bind + Unbind, B> {
     Unit,
+    EmptyStruct {},
+    EmptyTuple(),
     Tuple(#[binding(include)] A, &'a B, A),
 }
 


### PR DESCRIPTION
Summary:
The current implementation adds an extra `,` for empty struct variant in enum:

```
enum MyEnum {
    EmptyStruct {},
}
```

which made the generate code uncompilable. This diff fixes that.

Differential Revision: D78184202


