### PR TITLE
Python actor mesh supervision support

### DIFF
--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -505,13 +505,13 @@ pub fn initialize_logging(clock: impl TelemetryClock + Send + 'static) {
             } else {
                 None
             })
+            .with(file_layer)
+            .with(stderr_layer)
             .with(if is_layer_enabled(DISABLE_RECORDER_TRACING) {
                 Some(recorder().layer())
             } else {
                 None
             })
-            .with(file_layer)
-            .with(stderr_layer)
             .try_init()
         {
             tracing::debug!("logging already initialized for this process: {}", err);

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -79,6 +79,11 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
         "monarch_hyperactor.selection",
     )?)?;
 
+    monarch_hyperactor::supervision::register_python_bindings(&get_or_add_new_module(
+        module,
+        "monarch_hyperactor.supervision",
+    )?)?;
+
     #[cfg(feature = "tensor_engine")]
     {
         client::register_python_bindings(&get_or_add_new_module(

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -6,35 +6,96 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::sync::Arc;
+
 use hyperactor::ActorRef;
+use hyperactor::id;
+use hyperactor::mailbox::OncePortReceiver;
+use hyperactor::mailbox::PortReceiver;
+use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_mesh::Mesh;
 use hyperactor_mesh::RootActorMesh;
 use hyperactor_mesh::actor_mesh::ActorMesh;
+use hyperactor_mesh::actor_mesh::ActorSupervisionEvents;
 use hyperactor_mesh::shared_cell::SharedCell;
 use hyperactor_mesh::shared_cell::SharedCellRef;
+use pyo3::exceptions::PyEOFError;
 use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use tokio::sync::Mutex;
 
 use crate::actor::PythonActor;
 use crate::actor::PythonMessage;
 use crate::mailbox::PyMailbox;
+use crate::mailbox::PythonOncePortReceiver;
+use crate::mailbox::PythonPortReceiver;
 use crate::proc::PyActorId;
 use crate::proc_mesh::Keepalive;
+use crate::runtime::signal_safe_block_on;
 use crate::selection::PySelection;
 use crate::shape::PyShape;
+use crate::supervision::SupervisionError;
 
 #[pyclass(
     name = "PythonActorMesh",
     module = "monarch._rust_bindings.monarch_hyperactor.actor_mesh"
 )]
 pub struct PythonActorMesh {
-    pub(super) inner: SharedCell<RootActorMesh<'static, PythonActor>>,
-    pub client: PyMailbox,
-    pub(super) _keepalive: Keepalive,
+    inner: SharedCell<RootActorMesh<'static, PythonActor>>,
+    client: PyMailbox,
+    _keepalive: Keepalive,
+    unhealthy_event: Arc<std::sync::Mutex<Option<Option<ActorSupervisionEvent>>>>,
+    user_monitor_sender: tokio::sync::broadcast::Sender<Option<ActorSupervisionEvent>>,
+    monitor: tokio::task::JoinHandle<()>,
 }
 
 impl PythonActorMesh {
+    /// Create a new [`PythonActorMesh`] with a monitor that will observe supervision
+    /// errors for this mesh, and update its state properly.
+    pub(crate) fn monitored(
+        inner: SharedCell<RootActorMesh<'static, PythonActor>>,
+        client: PyMailbox,
+        keepalive: Keepalive,
+        events: ActorSupervisionEvents,
+    ) -> Self {
+        let (user_monitor_sender, _) =
+            tokio::sync::broadcast::channel::<Option<ActorSupervisionEvent>>(1);
+        let unhealthy_event = Arc::new(std::sync::Mutex::new(None));
+        let monitor = tokio::spawn(Self::actor_mesh_monitor(
+            events,
+            user_monitor_sender.clone(),
+            unhealthy_event.clone(),
+        ));
+        Self {
+            inner,
+            client,
+            _keepalive: keepalive,
+            unhealthy_event,
+            user_monitor_sender,
+            monitor,
+        }
+    }
+
+    /// Monitor of the actor mesh. It processes supervision errors for the mesh, and keeps mesh
+    /// health state up to date.
+    async fn actor_mesh_monitor(
+        mut events: ActorSupervisionEvents,
+        user_sender: tokio::sync::broadcast::Sender<Option<ActorSupervisionEvent>>,
+        unhealthy_event: Arc<std::sync::Mutex<Option<Option<ActorSupervisionEvent>>>>,
+    ) {
+        loop {
+            let event = events.next().await;
+            let mut inner_unhealthy_event = unhealthy_event.lock().unwrap();
+            *inner_unhealthy_event = Some(event.clone());
+
+            // Ignore the sender error when there is no receiver, which happens when there
+            // is no active requests to this mesh.
+            let _ = user_sender.send(event);
+        }
+    }
+
     fn try_inner(&self) -> PyResult<SharedCellRef<RootActorMesh<'static, PythonActor>>> {
         self.inner
             .borrow()
@@ -45,10 +106,38 @@ impl PythonActorMesh {
 #[pymethods]
 impl PythonActorMesh {
     fn cast(&self, selection: &PySelection, message: &PythonMessage) -> PyResult<()> {
+        let unhealthy_event = self
+            .unhealthy_event
+            .lock()
+            .expect("failed to acquire unhealthy_event lock");
+        if let Some(ref event) = *unhealthy_event {
+            return Err(PyRuntimeError::new_err(format!(
+                "actor mesh is unhealthy with reason: {:?}",
+                event
+            )));
+        }
+
         self.try_inner()?
             .cast(selection.inner().clone(), message.clone())
             .map_err(|err| PyException::new_err(err.to_string()))?;
         Ok(())
+    }
+
+    fn get_supervision_event(&self) -> PyResult<Option<PyActorSupervisionEvent>> {
+        let unhealthy_event = self
+            .unhealthy_event
+            .lock()
+            .expect("failed to acquire unhealthy_event lock");
+
+        Ok(unhealthy_event.as_ref().map(|event| match event {
+            None => PyActorSupervisionEvent {
+                // Dummy actor as place holder to indicate the whole mesh is stopped
+                // TODO(albertli): remove this when pushing all supervision logic to rust.
+                actor_id: id!(default[0].actor[0]).into(),
+                actor_status: "actor mesh is stopped due to proc mesh shutdown".to_string(),
+            },
+            Some(event) => PyActorSupervisionEvent::from(event.clone()),
+        }))
     }
 
     // Consider defining a "PythonActorRef", which carries specifically
@@ -61,6 +150,16 @@ impl PythonActorMesh {
             .map(PyActorId::from))
     }
 
+    // Start monitoring the actor mesh by subscribing to its supervision events. For each supervision
+    // event, it is consumed by PythonActorMesh first, then gets sent to the monitor for user to consume.
+    fn monitor<'py>(&self, py: Python<'py>) -> PyResult<PyObject> {
+        let receiver = self.user_monitor_sender.subscribe();
+        let monitor_instance = PyActorMeshMonitor {
+            receiver: SharedCell::from(Mutex::new(receiver)),
+        };
+        Ok(monitor_instance.into_py(py))
+    }
+
     #[getter]
     pub fn client(&self) -> PyMailbox {
         self.client.clone()
@@ -71,7 +170,218 @@ impl PythonActorMesh {
         Ok(PyShape::from(self.try_inner()?.shape().clone()))
     }
 }
+
+impl Drop for PythonActorMesh {
+    fn drop(&mut self) {
+        self.monitor.abort();
+    }
+}
+
+#[pyclass(
+    name = "ActorMeshMonitor",
+    module = "monarch._rust_bindings.monarch_hyperactor.actor_mesh"
+)]
+pub struct PyActorMeshMonitor {
+    receiver: SharedCell<Mutex<tokio::sync::broadcast::Receiver<Option<ActorSupervisionEvent>>>>,
+}
+
+#[pymethods]
+impl PyActorMeshMonitor {
+    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    pub fn __anext__(&self, py: Python<'_>) -> PyResult<PyObject> {
+        let receiver = self.receiver.clone();
+        Ok(pyo3_async_runtimes::tokio::future_into_py(py, get_next(receiver))?.into())
+    }
+}
+
+impl PyActorMeshMonitor {
+    pub async fn next(&self) -> PyResult<PyObject> {
+        get_next(self.receiver.clone()).await
+    }
+}
+
+impl Clone for PyActorMeshMonitor {
+    fn clone(&self) -> Self {
+        Self {
+            receiver: self.receiver.clone(),
+        }
+    }
+}
+
+async fn get_next(
+    receiver: SharedCell<Mutex<tokio::sync::broadcast::Receiver<Option<ActorSupervisionEvent>>>>,
+) -> PyResult<PyObject> {
+    let receiver = receiver.clone();
+
+    let receiver = receiver
+        .borrow()
+        .expect("`Actor mesh receiver` is shutdown");
+    let mut receiver = receiver.lock().await;
+    let event = receiver.recv().await.unwrap();
+
+    let supervision_event = match event {
+        None => PyActorSupervisionEvent {
+            // Dummy actor as place holder to indicate the whole mesh is stopped
+            // TODO(albertli): remove this when pushing all supervision logic to rust.
+            actor_id: id!(default[0].actor[0]).into(),
+            actor_status: "actor mesh is stopped due to proc mesh shutdown".to_string(),
+        },
+        Some(event) => PyActorSupervisionEvent::from(event.clone()),
+    };
+
+    Ok(Python::with_gil(|py| supervision_event.into_py(py)))
+}
+
+// TODO(albertli): this is temporary remove this when pushing all supervision logic to rust.
+#[pyclass(
+    name = "MonitoredPortReceiver",
+    module = "monarch._rust_bindings.monarch_hyperactor.actor_mesh"
+)]
+pub(super) struct MonitoredPythonPortReceiver {
+    inner: Arc<tokio::sync::Mutex<PortReceiver<PythonMessage>>>,
+    monitor: PyActorMeshMonitor,
+}
+
+#[pymethods]
+impl MonitoredPythonPortReceiver {
+    #[new]
+    fn new(receiver: &PythonPortReceiver, monitor: &PyActorMeshMonitor) -> Self {
+        let inner = receiver.inner();
+        MonitoredPythonPortReceiver {
+            inner,
+            monitor: monitor.clone(),
+        }
+    }
+
+    fn recv<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let receiver = self.inner.clone();
+        let monitor = self.monitor.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let mut receiver = receiver.lock().await;
+            tokio::select! {
+                result = receiver.recv() => {
+                    result.map_err(|err| PyErr::new::<PyEOFError, _>(format!("port closed: {}", err)))
+                }
+                event = monitor.next() => {
+                    Err(PyErr::new::<SupervisionError, _>(format!("supervision error: {:?}", event.unwrap())))
+                }
+            }
+        })
+    }
+
+    fn blocking_recv<'py>(&mut self, py: Python<'py>) -> PyResult<PythonMessage> {
+        let receiver = self.inner.clone();
+        let monitor = self.monitor.clone();
+        signal_safe_block_on(py, async move {
+            let mut receiver = receiver.lock().await;
+            tokio::select! {
+                result = receiver.recv() => {
+                   result.map_err(|err| PyErr::new::<PyEOFError, _>(format!("port closed: {}", err)))
+                }
+                event = monitor.next() => {
+                    Err(PyErr::new::<SupervisionError, _>(format!("supervision error: {:?}", event.unwrap())))
+                }
+            }
+        })?
+    }
+}
+
+#[pyclass(
+    name = "MonitoredOncePortReceiver",
+    module = "monarch._rust_bindings.monarch_hyperactor.actor_mesh"
+)]
+pub(super) struct MonitoredPythonOncePortReceiver {
+    inner: Arc<std::sync::Mutex<Option<OncePortReceiver<PythonMessage>>>>,
+    monitor: PyActorMeshMonitor,
+}
+
+#[pymethods]
+impl MonitoredPythonOncePortReceiver {
+    #[new]
+    fn new(receiver: &PythonOncePortReceiver, monitor: &PyActorMeshMonitor) -> Self {
+        let inner = receiver.inner();
+        MonitoredPythonOncePortReceiver {
+            inner,
+            monitor: monitor.clone(),
+        }
+    }
+
+    fn recv<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let Some(receiver) = self.inner.lock().unwrap().take() else {
+            return Err(PyErr::new::<PyValueError, _>("OncePort is already used"));
+        };
+        let monitor = self.monitor.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            tokio::select! {
+                result = receiver.recv() => {
+                    result.map_err(|err| PyErr::new::<PyEOFError, _>(format!("port closed: {}", err)))
+                }
+                event = monitor.next() => {
+                    Err(PyErr::new::<SupervisionError, _>(format!("supervision error: {:?}", event.unwrap())))
+                }
+            }
+        })
+    }
+
+    fn blocking_recv<'py>(&mut self, py: Python<'py>) -> PyResult<PythonMessage> {
+        let Some(receiver) = self.inner.lock().unwrap().take() else {
+            return Err(PyErr::new::<PyValueError, _>("OncePort is already used"));
+        };
+        let monitor = self.monitor.clone();
+        signal_safe_block_on(py, async move {
+            tokio::select! {
+                result = receiver.recv() => {
+                   result.map_err(|err| PyErr::new::<PyEOFError, _>(format!("port closed: {}", err)))
+                }
+                event = monitor.next() => {
+                    Err(PyErr::new::<SupervisionError, _>(format!("supervision error: {:?}", event.unwrap())))
+                }
+            }
+        })?
+    }
+}
+
+#[pyclass(
+    name = "ActorSupervisionEvent",
+    module = "monarch._rust_bindings.monarch_hyperactor.actor_mesh"
+)]
+pub struct PyActorSupervisionEvent {
+    /// Actor ID of the actor where supervision event originates from.
+    #[pyo3(get)]
+    actor_id: PyActorId,
+    /// String representation of the actor status.
+    /// TODO(T230628951): make it an enum or a struct for easier consumption.
+    #[pyo3(get)]
+    actor_status: String,
+}
+
+#[pymethods]
+impl PyActorSupervisionEvent {
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "<PyActorSupervisionEvent: actor_id: {:?}, status: {}>",
+            self.actor_id, self.actor_status
+        ))
+    }
+}
+
+impl From<ActorSupervisionEvent> for PyActorSupervisionEvent {
+    fn from(event: ActorSupervisionEvent) -> Self {
+        PyActorSupervisionEvent {
+            actor_id: event.actor_id().clone().into(),
+            actor_status: event.actor_status().to_string(),
+        }
+    }
+}
+
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_mod.add_class::<PythonActorMesh>()?;
+    hyperactor_mod.add_class::<PyActorMeshMonitor>()?;
+    hyperactor_mod.add_class::<MonitoredPythonPortReceiver>()?;
+    hyperactor_mod.add_class::<MonitoredPythonOncePortReceiver>()?;
+    hyperactor_mod.add_class::<PyActorSupervisionEvent>()?;
     Ok(())
 }

--- a/monarch_hyperactor/src/lib.rs
+++ b/monarch_hyperactor/src/lib.rs
@@ -21,6 +21,7 @@ pub mod proc_mesh;
 pub mod runtime;
 pub mod selection;
 pub mod shape;
+pub mod supervision;
 pub mod telemetry;
 
 #[cfg(fbcode_build)]

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -43,6 +43,7 @@ use crate::alloc::PyAlloc;
 use crate::mailbox::PyMailbox;
 use crate::runtime::signal_safe_block_on;
 use crate::shape::PyShape;
+use crate::supervision::SupervisionError;
 
 // A wrapper around `ProcMesh` which keeps track of all `RootActorMesh`s that it spawns.
 pub struct TrackedProcMesh {
@@ -114,8 +115,9 @@ pub struct PyProcMesh {
     pub inner: SharedCell<TrackedProcMesh>,
     keepalive: Keepalive,
     proc_events: SharedCell<Mutex<ProcEvents>>,
-    stop_monitor_sender: mpsc::Sender<bool>,
-    user_monitor_registered: AtomicBool,
+    user_monitor_receiver: SharedCell<Mutex<mpsc::UnboundedReceiver<ProcEvent>>>,
+    user_monitor_registered: Arc<AtomicBool>,
+    unhealthy_event: Arc<Mutex<Option<ProcEvent>>>,
 }
 
 fn allocate_proc_mesh<'py>(py: Python<'py>, alloc: &PyAlloc) -> PyResult<Bound<'py, PyAny>> {
@@ -155,24 +157,28 @@ fn allocate_proc_mesh_blocking<'py>(py: Python<'py>, alloc: &PyAlloc) -> PyResul
 }
 
 impl PyProcMesh {
-    /// Create a new [`PyProcMesh`] with a monitor that crashes the
-    /// process on any proc failure.
+    /// Create a new [`PyProcMesh`] with self health status monitoring.
     fn monitored(mut proc_mesh: ProcMesh, world_id: WorldId) -> Self {
-        let (sender, abort_receiver) = mpsc::channel::<bool>(1);
         let proc_events = SharedCell::from(Mutex::new(proc_mesh.events().unwrap()));
+        let (user_sender, user_receiver) = mpsc::unbounded_channel::<ProcEvent>();
+        let user_monitor_registered = Arc::new(AtomicBool::new(false));
+        let unhealthy_event = Arc::new(Mutex::new(None));
         let monitor = tokio::spawn(Self::default_proc_mesh_monitor(
             proc_events
                 .borrow()
                 .expect("borrowing immediately after creation"),
             world_id,
-            abort_receiver,
+            user_sender,
+            user_monitor_registered.clone(),
+            unhealthy_event.clone(),
         ));
         Self {
             inner: SharedCell::from(TrackedProcMesh::from(proc_mesh)),
             keepalive: Keepalive::new(monitor),
             proc_events,
-            stop_monitor_sender: sender,
-            user_monitor_registered: AtomicBool::new(false),
+            user_monitor_receiver: SharedCell::from(Mutex::new(user_receiver)),
+            user_monitor_registered: user_monitor_registered.clone(),
+            unhealthy_event,
         }
     }
 
@@ -181,33 +187,35 @@ impl PyProcMesh {
     async fn default_proc_mesh_monitor(
         events: SharedCellRef<Mutex<ProcEvents>>,
         world_id: WorldId,
-        mut abort_receiver: mpsc::Receiver<bool>,
+        user_sender: mpsc::UnboundedSender<ProcEvent>,
+        user_monitor_registered: Arc<AtomicBool>,
+        unhealthy_event: Arc<Mutex<Option<ProcEvent>>>,
     ) {
-        let mut proc_events = events.lock().await;
         loop {
+            let mut proc_events = events.lock().await;
             tokio::select! {
                 event = proc_events.next() => {
                     if let Some(event) = event {
+                        let mut inner_unhealthy_event = unhealthy_event.lock().await;
+                        *inner_unhealthy_event = Some(event.clone());
+
                         match event {
                             // A graceful stop should not be cause for alarm, but
                             // everything else should be considered a crash.
                             ProcEvent::Stopped(_, ProcStopReason::Stopped) => continue,
                             event => {
-                                eprintln!("ProcMesh {}: {}", world_id, event);
-                                std::process::exit(1)
+                                tracing::info!("ProcMesh {}: {}", world_id, event);
+                                if user_monitor_registered.load(std::sync::atomic::Ordering::SeqCst) {
+                                    if user_sender.send(event).is_err() {
+                                        tracing::error!("failed to deliver the supervision event to user");
+                                    }
+                                }
                             }
                         }
                     }
                 }
-                _ = async {
-                    tokio::select! {
-                        _ = events.preempted() => (),
-                        _ = abort_receiver.recv() => (),
-                    }
-                 } => {
-                    // The default monitor is aborted, this happens when user takes over
-                    // the monitoring responsibility.
-                    eprintln!("stop default supervision monitor for ProcMesh {}", world_id);
+                _ = events.preempted() => {
+                    tracing::error!("stop default supervision monitor for ProcMesh {}", world_id);
                     break;
                 }
             }
@@ -247,17 +255,28 @@ impl PyProcMesh {
         name: String,
         actor: &Bound<'py, PyType>,
     ) -> PyResult<Bound<'py, PyAny>> {
+        let unhealthy_event: Arc<Mutex<Option<ProcEvent>>> = self.unhealthy_event.clone();
         let pickled_type = PickledPyObject::pickle(actor.as_any())?;
         let proc_mesh = self.try_inner()?;
         let keepalive = self.keepalive.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let unhealthy_event = unhealthy_event.lock().await;
+            if let Some(unhealthy_event) = unhealthy_event.clone() {
+                return Err(SupervisionError::new_err(format!(
+                    "proc mesh is stopped with reason: {:?}",
+                    unhealthy_event
+                )));
+            }
+
             let mailbox = proc_mesh.client().clone();
             let actor_mesh = proc_mesh.spawn(&name, &pickled_type).await?;
-            let python_actor_mesh = PythonActorMesh {
-                inner: actor_mesh,
-                client: PyMailbox { inner: mailbox },
-                _keepalive: keepalive,
-            };
+            let actor_events = actor_mesh.with_mut(|a| a.events()).await.unwrap().unwrap();
+            let python_actor_mesh = PythonActorMesh::monitored(
+                actor_mesh,
+                PyMailbox { inner: mailbox },
+                keepalive,
+                actor_events,
+            );
             Python::with_gil(|py| python_actor_mesh.into_py_any(py))
         })
     }
@@ -268,17 +287,28 @@ impl PyProcMesh {
         name: String,
         actor: &Bound<'py, PyType>,
     ) -> PyResult<PyObject> {
+        let unhealthy_event = self.unhealthy_event.clone();
         let pickled_type = PickledPyObject::pickle(actor.as_any())?;
         let proc_mesh = self.try_inner()?;
         let keepalive = self.keepalive.clone();
         signal_safe_block_on(py, async move {
+            let unhealthy_event = unhealthy_event.lock().await;
+            if let Some(unhealthy_event) = unhealthy_event.clone() {
+                return Err(SupervisionError::new_err(format!(
+                    "proc mesh is stopped with reason: {:?}",
+                    unhealthy_event
+                )));
+            }
+
             let mailbox = proc_mesh.client().clone();
             let actor_mesh = proc_mesh.spawn(&name, &pickled_type).await?;
-            let python_actor_mesh = PythonActorMesh {
-                inner: actor_mesh,
-                client: PyMailbox { inner: mailbox },
-                _keepalive: keepalive,
-            };
+            let actor_events = actor_mesh.with_mut(|a| a.events()).await.unwrap().unwrap();
+            let python_actor_mesh = PythonActorMesh::monitored(
+                actor_mesh,
+                PyMailbox { inner: mailbox },
+                keepalive,
+                actor_events,
+            );
             Python::with_gil(|py| python_actor_mesh.into_py_any(py))
         })?
     }
@@ -287,6 +317,7 @@ impl PyProcMesh {
     // the default monitor that exits the client on process crash, so user can
     // handle the process crash in their own way.
     fn monitor<'py>(&mut self, py: Python<'py>) -> PyResult<PyObject> {
+        // TODO(alberlti): remove user_monitor_registered, use take() on `user_monitor_receiver`
         if self
             .user_monitor_registered
             .swap(true, std::sync::atomic::Ordering::SeqCst)
@@ -295,16 +326,10 @@ impl PyProcMesh {
                 "user already registered a monitor for this proc mesh".to_string(),
             ));
         }
-
-        // Stop the default monitor
-        let monitor_abort = self.stop_monitor_sender.clone();
-        let proc_events = self.proc_events.clone();
-
+        let receiver = self.user_monitor_receiver.clone();
         Ok(pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            monitor_abort.send(true).await.unwrap();
-
             // Create a new user monitor
-            Ok(PyProcMeshMonitor { proc_events })
+            Ok(PyProcMeshMonitor { receiver })
         })?
         .into())
     }
@@ -344,6 +369,7 @@ impl PyProcMesh {
                 // Grab the alloc back from `ProcEvents` and use that to stop the mesh.
                 let mut alloc = proc_events.take().await?.into_inner().into_alloc();
                 alloc.stop_and_wait().await?;
+
                 anyhow::Ok(())
             }
             .await?;
@@ -383,7 +409,7 @@ impl Drop for KeepaliveState {
     module = "monarch._rust_bindings.monarch_hyperactor.proc_mesh"
 )]
 pub struct PyProcMeshMonitor {
-    proc_events: SharedCell<Mutex<ProcEvents>>,
+    receiver: SharedCell<Mutex<mpsc::UnboundedReceiver<ProcEvent>>>,
 }
 
 #[pymethods]
@@ -393,17 +419,17 @@ impl PyProcMeshMonitor {
     }
 
     fn __anext__(&self, py: Python<'_>) -> PyResult<PyObject> {
-        let events = self.proc_events.clone();
+        let receiver = self.receiver.clone();
         Ok(pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            let events = events
+            let receiver = receiver
                 .borrow()
-                .map_err(|_| PyRuntimeError::new_err("`ProcEvents` is shutdown"))?;
-            let mut proc_events = events.lock().await;
+                .map_err(|_| PyRuntimeError::new_err("`ProcEvent receiver` is shutdown"))?;
+            let mut proc_event_receiver = receiver.lock().await;
             tokio::select! {
-                () = events.preempted() => {
-                    Err(PyRuntimeError::new_err("shutting down `ProcEvents`"))
+                () = receiver.preempted() => {
+                    Err(PyRuntimeError::new_err("shutting down `ProcEvents` receiver"))
                 },
-                event = proc_events.next() => {
+                event = proc_event_receiver.recv() => {
                     match event {
                         Some(event) => Ok(PyProcEvent::from(event)),
                         None => Err(::pyo3::exceptions::PyStopAsyncIteration::new_err(

--- a/monarch_hyperactor/src/supervision.rs
+++ b/monarch_hyperactor/src/supervision.rs
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use pyo3::create_exception;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+create_exception!(
+    monarch._rust_bindings.monarch_hyperactor.supervision,
+    SupervisionError,
+    PyRuntimeError
+);
+
+pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Get the Python interpreter instance from the module
+    let py = module.py();
+    // Add the exception to the module using its type object
+    module.add("SupervisionError", py.get_type::<SupervisionError>())?;
+    Ok(())
+}

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
@@ -6,10 +6,14 @@
 
 # pyre-strict
 
-from typing import final
+from typing import AsyncIterator, final
 
 from monarch._rust_bindings.monarch_hyperactor.actor import PythonMessage
-from monarch._rust_bindings.monarch_hyperactor.mailbox import Mailbox
+from monarch._rust_bindings.monarch_hyperactor.mailbox import (
+    Mailbox,
+    OncePortReceiver,
+    PortReceiver,
+)
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.selection import Selection
 from monarch._rust_bindings.monarch_hyperactor.shape import Shape
@@ -21,9 +25,22 @@ class PythonActorMesh:
         Cast a message to the selected actors in the mesh.
         """
 
+    def get_supervision_event(self) -> ActorSupervisionEvent | None:
+        """
+        Returns supervision event if there is any.
+        """
+        ...
+
     def get(self, rank: int) -> ActorId | None:
         """
         Get the actor id for the actor at the given rank.
+        """
+        ...
+
+    # TODO(albertli): remove this when pushing all supervision logic to Rust
+    def monitor(self) -> ActorMeshMonitor:
+        """
+        Returns a supervision monitor for this mesh.
         """
         ...
 
@@ -42,5 +59,73 @@ class PythonActorMesh:
         The Shape object that describes how the rank of an actor
         retrieved with get corresponds to coordinates in the
         mesh.
+        """
+        ...
+
+@final
+class ActorMeshMonitor:
+    def __aiter__(self) -> AsyncIterator["ActorSupervisionEvent"]:
+        """
+        Returns an async iterator for this monitor.
+        """
+        ...
+
+    async def __anext__(self) -> "ActorSupervisionEvent":
+        """
+        Returns the next proc event in the proc mesh.
+        """
+        ...
+
+@final
+class MonitoredPortReceiver:
+    """
+    A monitored receiver to which PythonMessages are sent.
+    """
+
+    def __init__(self, receiver: PortReceiver, monitor: ActorMeshMonitor) -> None:
+        """
+        Create a new monitored receiver from a PortReceiver.
+        """
+        ...
+
+    async def recv(self) -> PythonMessage:
+        """Receive a PythonMessage from the port's sender."""
+        ...
+    def blocking_recv(self) -> PythonMessage:
+        """Receive a single PythonMessage from the port's sender."""
+        ...
+
+@final
+class MonitoredOncePortReceiver:
+    """
+    A variant of monitored PortReceiver that can only receive a single message.
+    """
+
+    def __init__(self, receiver: OncePortReceiver, monitor: ActorMeshMonitor) -> None:
+        """
+        Create a new monitored receiver from a PortReceiver.
+        """
+        ...
+
+    async def recv(self) -> PythonMessage:
+        """Receive a single PythonMessage from the port's sender."""
+        ...
+    def blocking_recv(self) -> PythonMessage:
+        """Receive a single PythonMessage from the port's sender."""
+        ...
+
+@final
+class ActorSupervisionEvent:
+    @property
+    def actor_id(self) -> ActorId:
+        """
+        The actor id of the actor.
+        """
+        ...
+
+    @property
+    def actor_status(self) -> str:
+        """
+        Detailed actor status.
         """
         ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/supervision.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/supervision.pyi
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import final
+
+@final
+class SupervisionError(RuntimeError):
+    """
+    Custom exception for supervision-related errors in monarch_hyperactor.
+    """
+
+    ...

--- a/python/monarch/common/remote.py
+++ b/python/monarch/common/remote.py
@@ -144,7 +144,7 @@ class Remote(Generic[P, R], Endpoint[P, R]):
                 "Cannot create raw port objects with an old-style tensor engine controller."
             )
         mailbox: Mailbox = mesh_controller._mailbox
-        return PortTuple.create(mailbox, once)
+        return PortTuple.create(mailbox, None, once)
 
     @property
     def _resolvable(self):

--- a/python/monarch/mesh_controller.py
+++ b/python/monarch/mesh_controller.py
@@ -144,7 +144,9 @@ class MeshClient(Client):
         defs: Tuple["Tensor", ...],
         uses: Tuple["Tensor", ...],
     ) -> "OldFuture":  # the OldFuture is a lie
-        sender, receiver = PortTuple.create(self._mesh_controller._mailbox, once=True)
+        sender, receiver = PortTuple.create(
+            self._mesh_controller._mailbox, None, once=True
+        )
 
         ident = self.new_node(defs, uses, cast("OldFuture", sender))
         process = mesh._process(shard)
@@ -180,7 +182,9 @@ class MeshClient(Client):
         atexit.unregister(self._atexit)
         self._shutdown = True
 
-        sender, receiver = PortTuple.create(self._mesh_controller._mailbox, once=True)
+        sender, receiver = PortTuple.create(
+            self._mesh_controller._mailbox, None, once=True
+        )
         self._mesh_controller.sync_at_exit(sender._port_ref.port_id)
         receiver.recv().get(timeout=60)
         # we are not expecting anything more now, because we already


### PR DESCRIPTION
Summary:
This diff exposes the Rust ActorMesh supervision API to Python ActorMesh. It also wires the supervision events to endpoint calls, including *call()/call_one()/choose()/stream()*. So when a supervision error happens, all inflight calls will get notified, new calls will be failed.

The current diff fails the whole mesh when any actor fails in the mesh. A followup diff will provide more granular management here, such that we may only fail the calls that actually expect reply from the failed actors.

Reviewed By: colin2328

Differential Revision: D77434080


