### PR TITLE
handle gsapwn failures

### DIFF
--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -383,6 +383,7 @@ pub(crate) mod testing {
     use super::*;
     use crate::alloc::test_utils::TestActor;
     use crate::alloc::test_utils::Wait;
+    use crate::proc_mesh::mesh_agent::GspawnResult;
     use crate::proc_mesh::mesh_agent::MeshAgentMessageClient;
 
     #[macro_export]
@@ -517,8 +518,13 @@ pub(crate) mod testing {
             )
             .await
             .unwrap();
-        let (_, actor_id) = completed_receiver.recv().await.unwrap();
-        ActorRef::attest(actor_id)
+        let result = completed_receiver.recv().await.unwrap();
+        match result {
+            GspawnResult::Success { actor_id, .. } => ActorRef::attest(actor_id),
+            GspawnResult::Error(error_msg) => {
+                panic!("gspawn failed: {}", error_msg);
+            }
+        }
     }
 
     /// In order to simulate stuckness, we have to do two things:


### PR DESCRIPTION
Summary:
gspawn failures can cause the sender to hang forever given there is no
reply message received. This patch captures the error and force sending a
result back no matter what.

This is only a short-term mitigation on this specific call. We need to provide
a better infra for such RPC behavior (probably port ref is enough). Then we
don't have to hand write such failure handling everywhere.

**I will spend sometime to explore the proper fix to `PortRef`**

Differential Revision: D78231155


