### PR TITLE
: selection: bugfix reifying strided views

### DIFF
--- a/ndslice/src/slice.rs
+++ b/ndslice/src/slice.rs
@@ -35,6 +35,9 @@ pub enum SliceError {
 
     #[error("incompatible view: {reason}")]
     IncompatibleView { reason: String },
+
+    #[error("noncontiguous shape")]
+    NonContiguous,
 }
 
 /// Slice is a compact representation of indices into the flat


### PR DESCRIPTION
Summary:
**fix two bugs**

thanks go to pzhan9 for reporting these issues! (see D78298712)

(1) one in `reify_view` where views with strides were reified incorrectly. the old code assumed views could always be expressed as contiguous `range(start..start + len)` expressions, even when the view's stride differed from the base. this produced incorrect selections when the view was strided relative to the base layout.

the fix is to recognize when a view is layout-aligned; that is, when each of its strides is an integer multiple of the corresponding base stride, including the unitary case; and to reify such views using `Range(start, Some(end), step)` expressions that preserve both shape and layout. previously, only the unitary case (`step` = 1) was handled. this change extends support to non-unitary aligned views, such as `step` = 2, by correctly computing the step factor and corresponding end coordinate.

if any dimension is not layout-aligned — that is, if `view_stride` % `base_stride` ≠ 0 — we conservatively fall back to enumerating all selected coordinates explicitly.

(2) also fixes a bug in `Shape::select()` where the length of a strided range was computed using truncating division. this now correctly uses ceiling division to ensure all selected indices are included.

Differential Revision: D78315005


