### PR TITLE
Don't close-on-drop if already shutdown

### DIFF
--- a/monarch_extension/src/code_sync.rs
+++ b/monarch_extension/src/code_sync.rs
@@ -119,7 +119,8 @@ impl RsyncMeshClient {
         let shape = self.shape.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let mesh = SlicedActorMesh::new(&inner_mesh, shape);
-            Ok(rsync::rsync_mesh(&mesh, workspace).await?)
+            rsync::rsync_mesh(&mesh, workspace).await?;
+            Ok(())
         })
     }
 }


### PR DESCRIPTION
Summary:
Fix a bug where we'd send another EOF (to a potentially closed channel)
after we'd already shutdown the stream.

Reviewed By: highker

Differential Revision: D78286093


