### PR TITLE
stop logging duplicate supervision stream closed log

### DIFF
--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -97,7 +97,12 @@ impl PythonActorMesh {
 
             // Ignore the sender error when there is no receiver, which happens when there
             // is no active requests to this mesh.
-            let _ = user_sender.send(event);
+            let _ = user_sender.send(event.clone());
+
+            if event.is_none() {
+                // The mesh is stopped, so we can stop the monitor.
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Summary: When a mesh is stopped, we log the error once and exit the monitoring task.

Reviewed By: vidhyav

Differential Revision: D78424407


