### PR TITLE
Add logs for dropping alloc

### DIFF
--- a/hyperactor_mesh/src/alloc/local.rs
+++ b/hyperactor_mesh/src/alloc/local.rs
@@ -269,6 +269,16 @@ impl Alloc for LocalAlloc {
     }
 }
 
+impl Drop for LocalAlloc {
+    fn drop(&mut self) {
+        tracing::debug!(
+            "dropping LocalAlloc of name: {}, world id: {}",
+            self.name,
+            self.world_id
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/hyperactor_mesh/src/alloc/process.rs
+++ b/hyperactor_mesh/src/alloc/process.rs
@@ -499,6 +499,16 @@ impl Alloc for ProcessAlloc {
     }
 }
 
+impl Drop for ProcessAlloc {
+    fn drop(&mut self) {
+        tracing::debug!(
+            "dropping ProcessAlloc of name: {}, world id: {}",
+            self.name,
+            self.world_id
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -993,6 +993,12 @@ impl Alloc for RemoteProcessAlloc {
     }
 }
 
+impl Drop for RemoteProcessAlloc {
+    fn drop(&mut self) {
+        tracing::debug!("dropping RemoteProcessAlloc of world_id {}", self.world_id);
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::assert_matches::assert_matches;


### PR DESCRIPTION
Summary: These logs will make it easy to tell when alloc is dropped. This information could be helpful when debugging shutdown related bugs.

Differential Revision: D78438679


