### PR TITLE
Spawn signal handler out of loop into background task

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use futures::StreamExt;
@@ -20,9 +21,11 @@ use hyperactor::channel::Tx;
 use hyperactor::clock::Clock;
 use hyperactor::clock::RealClock;
 use hyperactor::mailbox::MailboxServer;
+use hyperactor::proc::Proc;
 use serde::Deserialize;
 use serde::Serialize;
 use signal_hook::consts::signal::SIGTERM;
+use tokio::sync::Mutex;
 
 use crate::proc_mesh::mesh_agent::MeshAgent;
 
@@ -126,6 +129,43 @@ async fn exit_if_missed_heartbeat(bootstrap_index: usize, bootstrap_addr: Channe
 pub async fn bootstrap() -> anyhow::Error {
     pub async fn go() -> Result<(), anyhow::Error> {
         let mut signals = signal_hook_tokio::Signals::new([SIGTERM])?;
+        let procs = Arc::new(Mutex::new(Vec::<Proc>::new()));
+        {
+            let procs = procs.clone();
+            tokio::spawn(async move {
+                if let Some(signal) = signals.next().await {
+                    if let Ok(signal) = nix::sys::signal::Signal::try_from(signal) {
+                        {
+                            for proc_to_stop in procs.lock().await.iter_mut() {
+                                if let Err(err) = proc_to_stop
+                                    .destroy_and_wait(Duration::from_millis(10), None)
+                                    .await
+                                {
+                                    tracing::error!(
+                                        "error while stopping proc {}: {}",
+                                        proc_to_stop.proc_id(),
+                                        err
+                                    );
+                                }
+                            }
+                        }
+                        // SAFETY: We're setting the handle to SigDfl (default system behaviour)
+                        if let Err(err) = unsafe {
+                            nix::sys::signal::signal(signal, nix::sys::signal::SigHandler::SigDfl)
+                        } {
+                            tracing::error!(
+                                "failed to reset {:?} to default signal handler: {}",
+                                signal,
+                                err
+                            );
+                        }
+                        if let Err(err) = nix::sys::signal::raise(signal) {
+                            tracing::error!("failed to raise {:?}: {}", signal, err);
+                        }
+                    }
+                }
+            });
+        }
 
         let bootstrap_addr: ChannelAddr = std::env::var(BOOTSTRAP_ADDR_ENV)
             .map_err(|err| anyhow::anyhow!("read `{}`: {}", BOOTSTRAP_ADDR_ENV, err))?
@@ -145,58 +185,31 @@ pub async fn bootstrap() -> anyhow::Error {
 
         tokio::spawn(exit_if_missed_heartbeat(bootstrap_index, bootstrap_addr));
 
-        let mut procs = Vec::new();
-
         loop {
             let _ = hyperactor::tracing::info_span!("wait_for_next_message_from_mesh_agent");
-            tokio::select! {
-                msg = rx.recv() => {
-                    match msg? {
-                        Allocator2Process::StartProc(proc_id, listen_transport) => {
-                            let (proc, mesh_agent) = MeshAgent::bootstrap(proc_id.clone()).await?;
-                            let (proc_addr, proc_rx) =
-                                channel::serve(ChannelAddr::any(listen_transport)).await?;
-                            // Undeliverable messages get forwarded to the mesh agent.
-                            let handle = proc.clone().serve(proc_rx, mesh_agent.port());
-                            drop(handle); // linter appeasement; it is safe to drop this future
-                            tx.send(Process2Allocator(
-                                bootstrap_index,
-                                Process2AllocatorMessage::StartedProc(
-                                    proc_id.clone(),
-                                    mesh_agent.bind(),
-                                    proc_addr,
-                                ),
-                            ))
-                            .await?;
-                            procs.push(proc);
-                        }
-                        Allocator2Process::StopAndExit(code) => {
-                            tracing::info!("stopping procs with code {code}");
-                            for mut proc_to_stop in procs {
-                                if let Err(err) = proc_to_stop
-                                    .destroy_and_wait(Duration::from_millis(10), None)
-                                    .await
-                                {
-                                    tracing::error!(
-                                        "error while stopping proc {}: {}",
-                                        proc_to_stop.proc_id(),
-                                        err
-                                    );
-                                }
-                            }
-                            tracing::info!("exiting with {code}");
-                            std::process::exit(code);
-                        }
-                        Allocator2Process::Exit(code) => {
-                            tracing::info!("exiting with {code}");
-                            std::process::exit(code);
-                        }
-                    }
+            match rx.recv().await? {
+                Allocator2Process::StartProc(proc_id, listen_transport) => {
+                    let (proc, mesh_agent) = MeshAgent::bootstrap(proc_id.clone()).await?;
+                    let (proc_addr, proc_rx) =
+                        channel::serve(ChannelAddr::any(listen_transport)).await?;
+                    // Undeliverable messages get forwarded to the mesh agent.
+                    let handle = proc.clone().serve(proc_rx, mesh_agent.port());
+                    drop(handle); // linter appeasement; it is safe to drop this future
+                    tx.send(Process2Allocator(
+                        bootstrap_index,
+                        Process2AllocatorMessage::StartedProc(
+                            proc_id.clone(),
+                            mesh_agent.bind(),
+                            proc_addr,
+                        ),
+                    ))
+                    .await?;
+                    procs.lock().await.push(proc);
                 }
-                signal = signals.next() => {
-                    if signal.is_some_and(|sig| sig == SIGTERM) {
-                        tracing::info!("received SIGTERM, stopping procs");
-                        for mut proc_to_stop in procs {
+                Allocator2Process::StopAndExit(code) => {
+                    tracing::info!("stopping procs with code {code}");
+                    {
+                        for proc_to_stop in procs.lock().await.iter_mut() {
                             if let Err(err) = proc_to_stop
                                 .destroy_and_wait(Duration::from_millis(10), None)
                                 .await
@@ -208,17 +221,13 @@ pub async fn bootstrap() -> anyhow::Error {
                                 );
                             }
                         }
-                        // SAFETY: We're setting the handle to SigDfl (defautl system behaviour)
-                        if let Err(err) = unsafe {
-                            nix::sys::signal::signal(nix::sys::signal::SIGTERM, nix::sys::signal::SigHandler::SigDfl)
-                        } {
-                            tracing::error!("failed to signal SIGTERM: {}", err);
-                        }
-                        if let Err(err) = nix::sys::signal::raise(nix::sys::signal::SIGTERM) {
-                            tracing::error!("failed to raise SIGTERM: {}", err);
-                        }
-                        std::process::exit(128 + SIGTERM);
                     }
+                    tracing::info!("exiting with {code}");
+                    std::process::exit(code);
+                }
+                Allocator2Process::Exit(code) => {
+                    tracing::info!("exiting with {code}");
+                    std::process::exit(code);
                 }
             }
         }


### PR DESCRIPTION
Summary:
This fixes `test_allocator_stuck_job`.

Previously we had a problem where if we branched into any of the message handler branches where we called `std::process::exit()` the loop would break and we would not be able to receive any signals. This would result in us being unable to kill the process with SIGTERM which is why the broken test would hang. Spawning the signal handler in a background task ensures that even once the loop breaks we can still listen for signals and handle them

Differential Revision: D78516491


