### PR TITLE
fix lints

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -22,7 +22,6 @@ use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::Named;
-use hyperactor::cap::CanSend;
 use hyperactor::forward;
 use hyperactor::message::Bind;
 use hyperactor::message::Bindings;

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -20,6 +20,7 @@ use hyperactor_mesh::actor_mesh::ActorSupervisionEvents;
 use hyperactor_mesh::reference::ActorMeshRef;
 use hyperactor_mesh::shared_cell::SharedCell;
 use hyperactor_mesh::shared_cell::SharedCellRef;
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyEOFError;
 use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyNotImplementedError;
@@ -389,7 +390,7 @@ async fn get_next(
         Some(event) => PyActorSupervisionEvent::from(event.clone()),
     };
 
-    Ok(Python::with_gil(|py| supervision_event.into_py(py)))
+    Python::with_gil(|py| supervision_event.into_py_any(py))
 }
 
 // TODO(albertli): this is temporary remove this when pushing all supervision logic to rust.

--- a/monarch_hyperactor/src/local_state_broker.rs
+++ b/monarch_hyperactor/src/local_state_broker.rs
@@ -54,7 +54,7 @@ impl Actor for LocalStateBrokerActor {
 impl Handler<LocalStateBrokerMessage> for LocalStateBrokerActor {
     async fn handle(
         &mut self,
-        cx: &Context<Self>,
+        _cx: &Context<Self>,
         message: LocalStateBrokerMessage,
     ) -> anyhow::Result<()> {
         match message {

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -9,7 +9,6 @@
 use std::hash::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
-use std::ops::Deref;
 use std::sync::Arc;
 
 use hyperactor::Mailbox;
@@ -36,7 +35,6 @@ use hyperactor::message::Bindings;
 use hyperactor::message::Unbind;
 use hyperactor_mesh::comm::multicast::set_cast_info_on_headers;
 use monarch_types::PickledPyObject;
-use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyEOFError;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::exceptions::PyValueError;


### PR DESCRIPTION
Summary: `monarch_hyperactor` is now lint free. handling the pyo3 deprecation warnings was helped by consulting D76757910.

Differential Revision: D78566222
