### PR TITLE
Use async functions in sync context to avoid code duplication.

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -32,6 +32,7 @@ use monarch_types::SerializablePyErr;
 use pyo3::conversion::IntoPyObjectExt;
 use pyo3::exceptions::PyBaseException;
 use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::PyStopIteration;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 use pyo3::types::PyDict;
@@ -615,18 +616,19 @@ impl Handler<PythonMessage> for PythonActor {
 /// Helper struct to make a Python future passable in an actor message.
 ///
 /// Also so that we don't have to write this massive type signature everywhere
-struct PythonTask {
+
+pub(crate) struct PythonTask {
     future: Mutex<Pin<Box<dyn Future<Output = PyResult<PyObject>> + Send + 'static>>>,
 }
 
 impl PythonTask {
-    fn new(fut: impl Future<Output = PyResult<PyObject>> + Send + 'static) -> Self {
+    pub(crate) fn new(fut: impl Future<Output = PyResult<PyObject>> + Send + 'static) -> Self {
         Self {
             future: Mutex::new(Box::pin(fut)),
         }
     }
 
-    async fn take(self) -> Pin<Box<dyn Future<Output = PyResult<PyObject>> + Send + 'static>> {
+    fn take(self) -> Pin<Box<dyn Future<Output = PyResult<PyObject>> + Send + 'static>> {
         self.future.into_inner()
     }
 }
@@ -636,6 +638,88 @@ impl fmt::Debug for PythonTask {
         f.debug_struct("PythonTask")
             .field("future", &"<PythonFuture>")
             .finish()
+    }
+}
+
+#[pyclass(
+    name = "PythonTask",
+    module = "monarch._rust_bindings.monarch_hyperactor.actor"
+)]
+pub struct PyPythonTask {
+    inner: Option<PythonTask>,
+}
+
+impl From<PythonTask> for PyPythonTask {
+    fn from(task: PythonTask) -> Self {
+        Self { inner: Some(task) }
+    }
+}
+
+#[pyclass(
+    name = "JustStopWithValueIterator",
+    module = "monarch._rust_bindings.monarch_hyperactor.actor"
+)]
+struct JustStopWithValueIterator {
+    value: Option<PyObject>,
+}
+
+#[pymethods]
+impl JustStopWithValueIterator {
+    fn __next__(&mut self) -> PyResult<PyObject> {
+        Err(PyStopIteration::new_err(self.value.take().unwrap()))
+    }
+}
+
+impl PyPythonTask {
+    pub fn new<F, T>(fut: F) -> PyResult<Self>
+    where
+        F: Future<Output = PyResult<T>> + Send + 'static,
+        T: for<'py> IntoPyObject<'py>,
+    {
+        Ok(PythonTask::new(async {
+            fut.await
+                .and_then(|t| Python::with_gil(|py| t.into_py_any(py)))
+        })
+        .into())
+    }
+}
+
+#[pymethods]
+impl PyPythonTask {
+    fn into_future(&mut self, py: Python<'_>) -> PyResult<PyObject> {
+        let task = self
+            .inner
+            .take()
+            .map(|task| task.take())
+            .expect("PythonTask already consumed");
+        Ok(pyo3_async_runtimes::tokio::future_into_py(py, task)?.unbind())
+    }
+    fn block_on(&mut self, py: Python<'_>) -> PyResult<PyObject> {
+        let task = self
+            .inner
+            .take()
+            .map(|task| task.take())
+            .expect("PythonTask already consumed");
+        signal_safe_block_on(py, task)?
+    }
+
+    /// In an async context this turns the tokio::Future into
+    /// an asyncio Future and awaits it.
+    /// In a synchronous context, this just blocks on the future and
+    /// immediately returns the value without pausing caller coroutine.
+    /// See [avoiding async code duplication] for justitifcation.
+    fn __await__(&mut self, py: Python<'_>) -> PyResult<PyObject> {
+        let lp = py
+            .import("asyncio.events")
+            .unwrap()
+            .call_method0("_get_running_loop")
+            .unwrap();
+        if lp.is_none() {
+            let value = self.block_on(py)?;
+            Ok(JustStopWithValueIterator { value: Some(value) }.into_py_any(py)?)
+        } else {
+            self.into_future(py)?.call_method0(py, "__await__")
+        }
     }
 }
 
@@ -663,7 +747,7 @@ async fn handle_async_endpoint_panic(
             Err(_) => pending().await,
         }
     };
-    let future = task.take().await;
+    let future = task.take();
     let result: anyhow::Result<(), SerializablePyErr> = tokio::select! {
         result = future => {
             match result {
@@ -688,6 +772,7 @@ pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResul
     hyperactor_mod.add_class::<PythonMessageKind>()?;
     hyperactor_mod.add_class::<UnflattenArg>()?;
     hyperactor_mod.add_class::<PanicFlag>()?;
+    hyperactor_mod.add_class::<PyPythonTask>()?;
     Ok(())
 }
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor_mesh.pyi
@@ -13,6 +13,7 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     Mailbox,
     OncePortReceiver,
     PortReceiver,
+    PortReceiverBase,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorId
 from monarch._rust_bindings.monarch_hyperactor.selection import Selection
@@ -128,7 +129,7 @@ class ActorMeshMonitor:
         ...
 
 @final
-class MonitoredPortReceiver:
+class MonitoredPortReceiver(PortReceiverBase):
     """
     A monitored receiver to which PythonMessages are sent.
     """
@@ -139,15 +140,8 @@ class MonitoredPortReceiver:
         """
         ...
 
-    async def recv(self) -> PythonMessage:
-        """Receive a PythonMessage from the port's sender."""
-        ...
-    def blocking_recv(self) -> PythonMessage:
-        """Receive a single PythonMessage from the port's sender."""
-        ...
-
 @final
-class MonitoredOncePortReceiver:
+class MonitoredOncePortReceiver(PortReceiverBase):
     """
     A variant of monitored PortReceiver that can only receive a single message.
     """
@@ -156,13 +150,6 @@ class MonitoredOncePortReceiver:
         """
         Create a new monitored receiver from a PortReceiver.
         """
-        ...
-
-    async def recv(self) -> PythonMessage:
-        """Receive a single PythonMessage from the port's sender."""
-        ...
-    def blocking_recv(self) -> PythonMessage:
-        """Receive a single PythonMessage from the port's sender."""
         ...
 
 @final

--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import asyncio
+import traceback
 from functools import partial
 from typing import Generator, Generic, Optional, TypeVar
 
@@ -27,17 +28,55 @@ async def _aincomplete(impl, self):
         raise
 
 
-# TODO: consolidate with monarch.common.future
+# Future is our generic mechanism for providing both a synchronous and asynchronous API for
+# Monarch Future objects.
+
+# We treat all code as running in one of two contexts: synchronous (asyncio._get_running_loop() is None)
+# or asynchronous.
+
+# Inside of asynchronous code, clients of our API must use `await` to wait for monarch Futures to prevent
+# blocking the surrounding event loop.
+
+# In synchronous code users must call get() because the call is comming from an non-async function so
+# await is not allowed.
+
+# [avoiding async code duplication]
+# Because we allow for two modes, it is tempting as developers of Monarch to start to write two copies of
+# of code for each mode. However, this results in a lot of confusing code duplication.
+# To avoid this, we utilize the fact that synchronous code is allowed to start/complete an asyncio event loop
+# via asyncio.run in order to complete the `get()` operation. So we can just write the async version and use
+# it to implement the synchronoous version.
+
+# However, starting and running an event loop is somewhat expensive. For simple messages, using an event loop
+# is about 4x slower than just directly waiting on the tokio result. To avoid this slow down we perform an
+# optimization. For any case where the `impl` coroutine of a future calls `await` only on PythonFuture
+# (a Tokio future returning a Python value) objects, we pass requires_loop=False to the Future. In this mode,
+# the future will just run the coroutine manually, and the PythonFuture object will recognize it is being awaited
+# without an event loop (search [avoiding code duplication]) and simply do a blocking wait. By avoiding the event
+# loop machinery, this gives it the same throughput as if we ran it synchronously.
+
+
 class Future(Generic[R]):
-    def __init__(self, impl, blocking_impl=None):
+    def __init__(self, impl, blocking_impl=None, requires_loop=True):
         if blocking_impl is None:
             blocking_impl = partial(asyncio.run, impl())
         self._get = partial(_incomplete, blocking_impl)
         self._aget = partial(_aincomplete, impl)
+        self._requires_loop = requires_loop
 
     def get(self, timeout: Optional[float] = None) -> R:
         if timeout is not None:
             return asyncio.run(asyncio.wait_for(self._aget(self), timeout))
+        if not self._requires_loop:
+            try:
+                coro = self._aget(self)
+                next(coro.__await__())
+                tb_str = "".join(traceback.format_stack(coro.cr_frame))
+                raise RuntimeError(
+                    f"a coroutine paused with a future with requires_loop=False cannot block on a python asyncio.Future. Use requires_loop=True.\n{tb_str}"
+                )
+            except StopIteration as e:
+                return e.value
         return self._get(self)
 
     def __await__(self) -> Generator[R, None, R]:

--- a/python/tests/_monarch/test_actor_mesh.py
+++ b/python/tests/_monarch/test_actor_mesh.py
@@ -102,7 +102,7 @@ async def verify_cast(
 
     rcv_ranks = []
     for _ in range(len(cast_ranks)):
-        message = await receiver.recv()
+        message = await receiver.recv_task().into_future()
         result_kind = message.kind
         assert isinstance(result_kind, PythonMessageKind.Result)
         rank = result_kind.rank
@@ -112,7 +112,7 @@ async def verify_cast(
     assert rcv_ranks == cast_ranks
     # verify no more messages are received
     with pytest.raises(asyncio.exceptions.TimeoutError):
-        await asyncio.wait_for(receiver.recv(), timeout=1)
+        await asyncio.wait_for(receiver.recv_task().into_future(), timeout=1)
 
 
 @pytest.mark.timeout(30)

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -114,7 +114,7 @@ async def test_accumulator() -> None:
         )
 
     async def recv_message() -> str:
-        messge = await asyncio.wait_for(receiver.recv(), timeout=5)
+        messge = await asyncio.wait_for(receiver.recv_task().into_future(), timeout=5)
         value = pickle.loads(messge.message)
         return cast(str, value)
 
@@ -177,6 +177,6 @@ async def test_reducer() -> None:
         ),
     )
 
-    messge = await asyncio.wait_for(receiver.recv(), timeout=5)
+    messge = await asyncio.wait_for(receiver.recv_task().into_future(), timeout=5)
     value = cast(str, pickle.loads(messge.message))
     assert "[reduced](start+msg0)" in value


### PR DESCRIPTION
Summary:
We currently have a lot of code duplication for blocking/nonblocking variants.

This PR lets the blocking variants be defined in terms of the async ones.

It first directly exposes the tokio Future object to python, letting it choose to synchronously block on it, or turn it into a asyncio.Future. Then when we are running async code to do pipe receives in a sync context, we can skip running a real event loop and just step the coroutine manually.

See [avoiding async code duplication] in the diff for a description of the approach.


Currently there is jank around the fact that we are running synchronous actor code on a thread that already has a running event loop. To indicate to the synchronous actor that it is ok to `get()` despite this setup, we temporarily blank out the running asyncio loop while a asynchronous actor is running a message. We need to eventually figure out a way to get the synchronous actors running on a thread that truly is not the asyncio event loop.

Reviewed By: eliothedeman, colin2328

Differential Revision: D78466520


