### PR TITLE
Package rsync for use with code sync

### DIFF
--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -22,6 +22,7 @@ hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 hyperactor_multiprocess = { version = "0.0.0", path = "../hyperactor_multiprocess" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 inventory = "0.3.8"
+lazy_static = "1.5"
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 nix = { version = "0.29.0", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
@@ -36,3 +37,7 @@ tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 
 [dev-dependencies]
 dir-diff = "0.3"
+
+[features]
+default = ["packaged_rsync"]
+packaged_rsync = []

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -8,6 +8,7 @@
 
 use std::path::PathBuf;
 
+use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::ensure;
 use async_once_cell::OnceCell;
@@ -227,7 +228,17 @@ impl CodeSyncMessageHandler for CodeSyncManager {
             anyhow::Ok(())
         }
         .await;
-        result.send(cx, res.map_err(|e| format!("{:#?}", e)))?;
+        result.send(
+            cx,
+            res.map_err(|e| {
+                format!(
+                    "{:#?}",
+                    Err::<(), _>(e)
+                        .with_context(|| format!("code sync from {}", cx.self_id()))
+                        .unwrap_err()
+                )
+            }),
+        )?;
         Ok(())
     }
 
@@ -238,7 +249,17 @@ impl CodeSyncMessageHandler for CodeSyncManager {
     ) -> Result<()> {
         // TODO(agallagher): Add reload.
         let res = async move { anyhow::Ok(()) }.await;
-        result.send(cx, res.map_err(|e| format!("{:#?}", e)))?;
+        result.send(
+            cx,
+            res.map_err(|e| {
+                format!(
+                    "{:#?}",
+                    Err::<(), _>(e)
+                        .with_context(|| format!("module reload from {}", cx.self_id()))
+                        .unwrap_err()
+                )
+            }),
+        )?;
         Ok(())
     }
 }

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -179,7 +179,8 @@ pub async fn do_rsync(addr: &SocketAddr, workspace: &Path) -> Result<RsyncResult
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
-        .await?;
+        .await
+        .context("spawning `rsync` binary")?;
 
     output
         .status

--- a/python/monarch/_src/actor/code_sync/auto_reload.py
+++ b/python/monarch/_src/actor/code_sync/auto_reload.py
@@ -120,7 +120,7 @@ class SysAuditImportHook:
             module = sys.modules.get(module_name)
             if module is None:
                 return
-            if module.__file__ is None:
+            if getattr(module, "__file__", None) is None:
                 return
             (code_obj,) = args
             if code_obj.co_filename is None:

--- a/python/tests/code_sync/test_auto_reload.py
+++ b/python/tests/code_sync/test_auto_reload.py
@@ -67,6 +67,18 @@ class TestAutoReloader(unittest.TestCase):
                 )
                 self.assertEqual(test_module.foo, 2)
 
+    def test_builtin_module_no_file_attribute(self):
+        """Test that modules without __file__ attribute don't cause AttributeError."""
+        reloader = AutoReloader()
+        with SysAuditImportHook.install(reloader.import_callback):
+            # C extensions don't have a `__file__` attr and won't trigger an "exec"
+            # event, so we're verifying that an unrelated "exec" (via `eval`) won't
+            # cause issues.
+            assert "_tracemalloc" not in sys.modules
+            import _tracemalloc  # noqa
+
+            eval("5")  # trigger `exec` event in the reloader
+
     def test_pyc_only_change(self):
         with importable_workspace() as workspace:
             reloader = AutoReloader()


### PR DESCRIPTION
Summary:
Some environments/systems don't provide rsync, so add a feature
to support packaging it.

Reviewed By: highker

Differential Revision: D78604141
