### PR TITLE
Add more context for remote rsync failures

### DIFF
--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -8,6 +8,7 @@
 
 use std::path::PathBuf;
 
+use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::ensure;
 use async_once_cell::OnceCell;
@@ -227,7 +228,17 @@ impl CodeSyncMessageHandler for CodeSyncManager {
             anyhow::Ok(())
         }
         .await;
-        result.send(cx, res.map_err(|e| format!("{:#?}", e)))?;
+        result.send(
+            cx,
+            res.map_err(|e| {
+                format!(
+                    "{:#?}",
+                    Err::<(), _>(e)
+                        .with_context(|| format!("code sync from {}", cx.self_id()))
+                        .unwrap_err()
+                )
+            }),
+        )?;
         Ok(())
     }
 
@@ -238,7 +249,17 @@ impl CodeSyncMessageHandler for CodeSyncManager {
     ) -> Result<()> {
         // TODO(agallagher): Add reload.
         let res = async move { anyhow::Ok(()) }.await;
-        result.send(cx, res.map_err(|e| format!("{:#?}", e)))?;
+        result.send(
+            cx,
+            res.map_err(|e| {
+                format!(
+                    "{:#?}",
+                    Err::<(), _>(e)
+                        .with_context(|| format!("module reload from {}", cx.self_id()))
+                        .unwrap_err()
+                )
+            }),
+        )?;
         Ok(())
     }
 }

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -179,7 +179,8 @@ pub async fn do_rsync(addr: &SocketAddr, workspace: &Path) -> Result<RsyncResult
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
-        .await?;
+        .await
+        .context("spawning `rsync` binary")?;
 
     output
         .status


### PR DESCRIPTION
Summary: Provides more error context when rsync fails to spawn remotely.

Reviewed By: highker

Differential Revision: D78604133


