### PR TITLE
: test_utils: pingpong undeliverable refinements

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -674,7 +674,8 @@ mod tests {
         let client = proc.attach("client").unwrap();
         let (undeliverable_msg_tx, _) = client.open_port();
 
-        let ping_pong_actor_params = PingPongActorParams::new(undeliverable_msg_tx.bind(), None);
+        let ping_pong_actor_params =
+            PingPongActorParams::new(Some(undeliverable_msg_tx.bind()), None);
         let ping_handle = proc
             .spawn::<PingPongActor>("ping", ping_pong_actor_params.clone())
             .await
@@ -705,7 +706,7 @@ mod tests {
 
         let error_ttl = 66;
         let ping_pong_actor_params =
-            PingPongActorParams::new(undeliverable_msg_tx.bind(), Some(error_ttl));
+            PingPongActorParams::new(Some(undeliverable_msg_tx.bind()), Some(error_ttl));
         let ping_handle = proc
             .spawn::<PingPongActor>("ping", ping_pong_actor_params.clone())
             .await

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -614,7 +614,7 @@ mod tests {
                 let mesh = ProcMesh::allocate(alloc).await.unwrap();
 
                 let (undeliverable_msg_tx, _) = mesh.client().open_port();
-                let ping_pong_actor_params = PingPongActorParams::new(undeliverable_msg_tx.bind(), None);
+                let ping_pong_actor_params = PingPongActorParams::new(Some(undeliverable_msg_tx.bind()), None);
                 let actor_mesh: RootActorMesh<PingPongActor> = mesh
                     .spawn::<PingPongActor>("ping-pong", &ping_pong_actor_params)
                     .await
@@ -649,7 +649,7 @@ mod tests {
 
                 let proc_mesh = ProcMesh::allocate(alloc).await.unwrap();
                 let (undeliverable_tx, _undeliverable_rx) = proc_mesh.client().open_port();
-                let params = PingPongActorParams::new(undeliverable_tx.bind(), None);
+                let params = PingPongActorParams::new(Some(undeliverable_tx.bind()), None);
                 let actor_mesh = proc_mesh.spawn::<PingPongActor>("pingpong", &params).await.unwrap();
                 let slice = actor_mesh.shape().slice();
 
@@ -921,7 +921,7 @@ mod tests {
             let mut events = mesh.events().unwrap();
 
             let ping_pong_actor_params = PingPongActorParams::new(
-                PortRef::attest_message_port(mesh.client().actor_id()),
+                Some(PortRef::attest_message_port(mesh.client().actor_id())),
                 None,
             );
             let actor_mesh: RootActorMesh<PingPongActor> = mesh
@@ -1052,7 +1052,7 @@ mod tests {
             let mesh = ProcMesh::allocate(alloc).await.unwrap();
 
             let ping_pong_actor_params = PingPongActorParams::new(
-                PortRef::attest_message_port(mesh.client().actor_id()),
+                Some(PortRef::attest_message_port(mesh.client().actor_id())),
                 None,
             );
             let mesh_one: RootActorMesh<PingPongActor> = mesh

--- a/hyperactor_multiprocess/src/ping_pong.rs
+++ b/hyperactor_multiprocess/src/ping_pong.rs
@@ -135,9 +135,7 @@ edges:
         .await
         .unwrap();
 
-        let (undeliverable_msg_tx, _) = sys_mailbox.open_port();
-
-        let params = PingPongActorParams::new(undeliverable_msg_tx.bind(), None);
+        let params = PingPongActorParams::new(None, None);
         spawn::<PingPongActor>(
             &sys_mailbox,
             &bootstrap.proc_actor.bind(),

--- a/hyperactor_multiprocess/src/proc_actor.rs
+++ b/hyperactor_multiprocess/src/proc_actor.rs
@@ -1426,7 +1426,7 @@ mod tests {
         let proc_1_client = proc_1.attach("client").unwrap();
         let (proc_1_undeliverable_tx, mut _proc_1_undeliverable_rx) = proc_1_client.open_port();
 
-        let ping_params = PingPongActorParams::new(proc_0_undeliverable_tx.bind(), None);
+        let ping_params = PingPongActorParams::new(Some(proc_0_undeliverable_tx.bind()), None);
         // Spawn two actors 'ping' and 'pong' where 'ping' runs on
         // 'world[0]' and 'pong' on 'world[1]' (that is, not on the
         // same proc).
@@ -1434,7 +1434,7 @@ mod tests {
             .spawn::<PingPongActor>("ping", ping_params)
             .await
             .unwrap();
-        let pong_params = PingPongActorParams::new(proc_1_undeliverable_tx.bind(), None);
+        let pong_params = PingPongActorParams::new(Some(proc_1_undeliverable_tx.bind()), None);
         let pong_handle = proc_1
             .spawn::<PingPongActor>("pong", pong_params)
             .await
@@ -1553,12 +1553,12 @@ mod tests {
         // Spawn two actors 'ping' and 'pong' where 'ping' runs on
         // 'world[0]' and 'pong' on 'world[1]' (that is, not on the
         // same proc).
-        let ping_params = PingPongActorParams::new(proc_0_undeliverable_tx.bind(), None);
+        let ping_params = PingPongActorParams::new(Some(proc_0_undeliverable_tx.bind()), None);
         let ping_handle = proc_0
             .spawn::<PingPongActor>("ping", ping_params)
             .await
             .unwrap();
-        let pong_params = PingPongActorParams::new(proc_1_undeliverable_tx.bind(), None);
+        let pong_params = PingPongActorParams::new(Some(proc_1_undeliverable_tx.bind()), None);
         let pong_handle = proc_1
             .spawn::<PingPongActor>("pong", pong_params)
             .await
@@ -1710,8 +1710,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let (undeliverable_msg_tx, _) = system_client.open_port();
-        let params = PingPongActorParams::new(undeliverable_msg_tx.bind(), None);
+        let params = PingPongActorParams::new(None, None);
         let actor_ref = spawn::<PingPongActor>(
             &system_client,
             &bootstrap.proc_actor.bind(),

--- a/hyperactor_multiprocess/src/system_actor.rs
+++ b/hyperactor_multiprocess/src/system_actor.rs
@@ -2704,12 +2704,12 @@ mod tests {
         // Spawn two actors 'ping' and 'pong' where 'ping' runs on
         // 'world[0]' and 'pong' on 'world[1]' (that is, not on the
         // same proc).
-        let ping_params = PingPongActorParams::new(proc_0_undeliverable_tx.bind(), None);
+        let ping_params = PingPongActorParams::new(Some(proc_0_undeliverable_tx.bind()), None);
         let ping_handle = proc_0
             .spawn::<PingPongActor>("ping", ping_params)
             .await
             .unwrap();
-        let pong_params = PingPongActorParams::new(proc_1_undeliverable_tx.bind(), None);
+        let pong_params = PingPongActorParams::new(Some(proc_1_undeliverable_tx.bind()), None);
         let pong_handle = proc_1
             .spawn::<PingPongActor>("pong", pong_params)
             .await


### PR DESCRIPTION
Summary: i aim to do more testing of undeliverable message handling and supervision. this change makes the `undeliverable_port_ref` parameter optional in `PingPongActorParams`. this generalization allows end-to-end testing of the default undeliverable message handling path by passing `None` for the port reference.

Differential Revision: D78673038


