### PR TITLE
Fix timeout changes for remote process allocator

### DIFF
--- a/hyperactor_mesh/src/alloc/remoteprocess.rs
+++ b/hyperactor_mesh/src/alloc/remoteprocess.rs
@@ -132,6 +132,8 @@ impl RemoteProcessAllocator {
     /// 4. Allocator sends Done message to bootstrap_addr when Alloc is done.
     ///
     /// At any point, client can send Stop message to serve_addr to stop the allocator.
+    /// If timeout is Some, the allocator will exit if no client connects within
+    /// that timeout, and no child allocation is running.
     pub async fn start(
         &self,
         cmd: Command,
@@ -145,8 +147,6 @@ impl RemoteProcessAllocator {
 
     /// Start a remote process allocator with given allocator listening for
     /// RemoteProcessAllocatorMessage on serve_addr.
-    /// If timeout is Some, the allocator will exit if no client connects within
-    /// that timeout, and no child allocation is running.
     /// Used for testing.
     pub async fn start_with_allocator<A: Allocator + Send + Sync + 'static>(
         &self,
@@ -247,7 +247,7 @@ impl RemoteProcessAllocator {
                     }
                     // Else, exit the loop as a client hasn't connected in a reasonable
                     // amount of time.
-                    tracing::warn!("timeout elapsed without any allocations, exiting");
+                    tracing::warn!("timeout of {} seconds elapsed without any allocations, exiting", timeout.unwrap_or_default().as_secs());
                     break;
                 }
             }

--- a/monarch_hyperactor/src/bin/process_allocator/common.rs
+++ b/monarch_hyperactor/src/bin/process_allocator/common.rs
@@ -42,10 +42,9 @@ pub struct Args {
 
     #[arg(
         long,
-        default_value_t = 0,
-        help = "If non-zero, a timeout for the allocator to wait before exiting. 0 means infinite wait"
+        help = "If specified, a timeout for the allocator to wait before exiting. Unspecified means no timeout"
     )]
-    pub timeout: u64,
+    pub timeout_sec: Option<u64>,
 }
 
 pub fn main_impl(

--- a/monarch_hyperactor/src/bin/process_allocator/main.rs
+++ b/monarch_hyperactor/src/bin/process_allocator/main.rs
@@ -28,11 +28,7 @@ async fn main() {
 
     let serve_address = ChannelAddr::from_str(&bind).unwrap();
     let program = Command::new(args.program);
-    let timeout = if args.timeout > 0 {
-        Some(Duration::from_secs(args.timeout))
-    } else {
-        None
-    };
+    let timeout = args.timeout_sec.map(Duration::from_secs);
 
     let _ = main_impl(serve_address, program, timeout).await.unwrap();
 }

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -102,7 +102,7 @@ def remote_process_allocator(
             f"--addr={addr}",
         ]
         if timeout is not None:
-            args.append(f"--timeout={timeout}")
+            args.append(f"--timeout-sec={timeout}")
 
         process_allocator = subprocess.Popen(
             args=args,


### PR DESCRIPTION
Summary:
Following up on comments to https://github.com/pytorch-labs/monarch/pull/583.
Suggestions:
* renamed `--timeout` to `--timeout-sec` so the unit is clear
* Changed default to `None` instead of `0` to avoid type confusion, and allow a 0 timeout if someone wanted that

Reviewed By: suo

Differential Revision: D78680097


