### PR TITLE
Fix deprecation warning about importlib.resources.path

### DIFF
--- a/hyper/tests/demo_test.py
+++ b/hyper/tests/demo_test.py
@@ -25,7 +25,9 @@ from later.unittest import TestCase
 
 @lru_cache()
 def hyper_bin() -> Path:
-    with resources.path((__package__ or "") + ".hyper", "hyper") as path:
+    with resources.as_file(
+        resources.files((__package__ or "") + ".hyper") / "hyper"
+    ) as path:
         return path
 
 

--- a/python/monarch/_src/actor/bootstrap_main.py
+++ b/python/monarch/_src/actor/bootstrap_main.py
@@ -48,7 +48,9 @@ def invoke_main():
 
     try:
         with (
-            importlib.resources.path("monarch", "py-spy") as pyspy,
+            importlib.resources.as_file(
+                importlib.resources.files("monarch") / "py-spy"
+            ) as pyspy,
         ):
             if pyspy.exists():
                 os.environ["PYSPY_BIN"] = str(pyspy)

--- a/python/monarch/rust_local_mesh.py
+++ b/python/monarch/rust_local_mesh.py
@@ -122,7 +122,9 @@ _PROC_ENV: dict[str, str] = {}
 
 def get_controller_main() -> tuple[Path, dict[str, str]]:
     with (
-        importlib.resources.path("monarch", "monarch_controller") as controller_main,
+        importlib.resources.as_file(
+            importlib.resources.files("monarch") / "monarch_controller"
+        ) as controller_main,
     ):
         if not controller_main.exists():
             if IN_PAR:

--- a/python/monarch/tensor_worker_main.py
+++ b/python/monarch/tensor_worker_main.py
@@ -249,7 +249,9 @@ if __name__ == "__main__":
     torch.cuda.set_device = check_set_device
 
     with (
-        importlib.resources.path("monarch", "py-spy") as pyspy,
+        importlib.resources.as_file(
+            importlib.resources.files("monarch") / "py-spy"
+        ) as pyspy,
     ):
         if pyspy.exists():
             os.environ["PYSPY_BIN"] = str(pyspy)

--- a/python/monarch_supervisor/python_executable.py
+++ b/python/monarch_supervisor/python_executable.py
@@ -29,8 +29,8 @@ if IN_PAR:
         PYTHON_EXECUTABLE = os.environ["FB_XAR_INVOKED_NAME"]
     else:
         try:
-            with importlib.resources.path(
-                "monarch_tensor_worker_env", "worker_env"
+            with importlib.resources.as_file(
+                importlib.resources.files("monarch_tensor_worker_env") / "worker_env"
             ) as path:
                 if not path.exists():
                     raise ImportError()

--- a/python/tests/test_allocator.py
+++ b/python/tests/test_allocator.py
@@ -95,7 +95,9 @@ def remote_process_allocator(
     """Start a remote process allocator on addr. If timeout is not None, have it
     timeout after that many seconds if no messages come in"""
 
-    with importlib.resources.path(__package__, "") as package_path:
+    with importlib.resources.as_file(
+        importlib.resources.files(__package__)
+    ) as package_path:
         addr = addr or ChannelAddr.any(ChannelTransport.Unix)
         args = [
             "process_allocator",


### PR DESCRIPTION
Summary:
Python begins giving a deprecation warning about this API somewhere in between
3.10 and 3.12. There's a simple migration using the `files` API instead.

Reviewed By: highker

Differential Revision: D78686748


