### PR TITLE
fix supervision error handling for undelivered message

### DIFF
--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -129,11 +129,7 @@ impl UndeliverableMessageError {
 /// Spawns a task that listens for undeliverable messages and posts a
 /// corresponding `ActorSupervisionEvent` to the given supervision
 /// port.
-///
-/// The `mailbox_id` identifies the source mailbox for context in
-/// supervision events.
 pub fn supervise_undeliverable_messages(
-    mailbox_id: ActorId,
     supervision_port: PortHandle<ActorSupervisionEvent>,
     mut rx: PortReceiver<Undeliverable<MessageEnvelope>>,
 ) {
@@ -144,7 +140,7 @@ pub fn supervise_undeliverable_messages(
             ));
             if supervision_port
                 .send(ActorSupervisionEvent::new(
-                    mailbox_id.clone(),
+                    envelope.dest().actor_id().clone(),
                     ActorStatus::Failed(format!("message not delivered: {}", envelope)),
                 ))
                 .is_err()

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -464,7 +464,11 @@ impl MonitoredPythonPortReceiver {
                     result.map_err(|err| PyErr::new::<PyEOFError, _>(format!("port closed: {}", err)))
                 }
                 event = monitor.next() => {
-                    Err(PyErr::new::<SupervisionError, _>(format!("supervision error: {:?}", event.unwrap())))
+                    let event = event.expect("supervision event should not be None");
+                    Python::with_gil(|py| {
+                        let e = event.downcast_bound::<PyActorSupervisionEvent>(py)?;
+                        Err(PyErr::new::<SupervisionError, _>(format!("supervision error: {:?}", e)))
+                    })
                 }
             };
             result.and_then(|message: PythonMessage| Python::with_gil(|py| message.into_py_any(py)))
@@ -503,7 +507,11 @@ impl MonitoredPythonOncePortReceiver {
                     result.map_err(|err| PyErr::new::<PyEOFError, _>(format!("port closed: {}", err)))
                 }
                 event = monitor.next() => {
-                    Err(PyErr::new::<SupervisionError, _>(format!("supervision error: {:?}", event.unwrap())))
+                    let event = event.expect("supervision event should not be None");
+                    Python::with_gil(|py| {
+                        let e = event.downcast_bound::<PyActorSupervisionEvent>(py)?;
+                        Err(PyErr::new::<SupervisionError, _>(format!("supervision error: {:?}", e)))
+                    })
                 }
             };
             result.and_then(|message: PythonMessage| Python::with_gil(|py| message.into_py_any(py)))

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -6,6 +6,7 @@
 
 
 import importlib.resources
+import os
 import subprocess
 import sys
 
@@ -450,6 +451,10 @@ class HealthyActor(Actor):
     async def check(self):
         return "this is a healthy check"
 
+    @endpoint
+    async def check_with_payload(self, payload: str):
+        pass
+
 
 class Intermediate(Actor):
     @endpoint
@@ -510,3 +515,28 @@ async def test_supervision_with_proc_mesh_stopped():
     # proc mesh cannot spawn new actors anymore
     with pytest.raises(RuntimeError, match="`ProcMesh` has already been stopped"):
         await proc.spawn("immediate", Intermediate)
+
+
+async def test_supervision_with_sending_error():
+    os.environ["HYPERACTOR_CODEC_MAX_FRAME_LENGTH"] = "9999999999"
+    os.environ["HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT_SECS"] = "1"
+
+    proc = await proc_mesh(gpus=1)
+    actor_mesh = await proc.spawn("healthy", HealthyActor)
+
+    await actor_mesh.check.call()
+
+    # send a small payload to trigger success
+    await actor_mesh.check_with_payload.call(payload="a")
+
+    # send a large payload to trigger send timeout error
+    with pytest.raises(
+        SupervisionError, match="supervision error:.*message not delivered:"
+    ):
+        await actor_mesh.check_with_payload.call(payload="a" * 2000000000)
+
+    # new call should fail with check of health state of actor mesh
+    with pytest.raises(SupervisionError, match="actor mesh is not in a healthy state"):
+        await actor_mesh.check.call()
+    with pytest.raises(SupervisionError, match="actor mesh is not in a healthy state"):
+        await actor_mesh.check_with_payload.call(payload="a")


### PR DESCRIPTION
Summary:
There is a bug in the undelivered message handling,  a supervision event is only generated for the proc mesh,
actor meshes are not getting the event. As a result, inflight futures on the actor meshes are not notified, could be hanging forever.

This diff fixes the problem.

Differential Revision: D78698921


