### PR TITLE
clean up get_or_create API

### DIFF
--- a/python/monarch/tools/cli.py
+++ b/python/monarch/tools/cli.py
@@ -86,9 +86,9 @@ class CreateCmd:
             else defaults.component_fn(config.scheduler)
         )
         component_args = component_args_from_cli(component_fn, args.component_args)
-        appdef = component_fn(**component_args)
+        config.appdef = component_fn(**component_args)
 
-        handle = create(config, appdef)
+        handle = create(config)
         print(handle)
 
 

--- a/python/monarch/tools/components/hyperactor.py
+++ b/python/monarch/tools/components/hyperactor.py
@@ -9,6 +9,7 @@ import getpass
 from typing import Optional
 
 from monarch.tools import mesh_spec
+from monarch.tools.config import UnnamedAppDef
 from monarch.tools.mesh_spec import mesh_spec_from_str
 from torchx import specs
 
@@ -16,17 +17,18 @@ _DEFAULT_MESHES = ["mesh_0:1:gpu.small"]
 
 _USER: str = getpass.getuser()
 
+DEFAULT_NAME: str = f"monarch-{_USER}"
+
 __version__ = "latest"  # TODO get version from monarch.__version_
 
 
 def proc_mesh(
-    name: str = f"monarch-{_USER}",
     image: str = f"ghcr.io/pytorch-labs/monarch:{__version__}",  # TODO docker needs to be built and pushed to ghcr
     meshes: list[str] = _DEFAULT_MESHES,
     env: Optional[dict[str, str]] = None,
     port: int = mesh_spec.DEFAULT_REMOTE_ALLOCATOR_PORT,
     program: str = "monarch_bootstrap",  # installed with monarch wheel (as console script)
-) -> specs.AppDef:
+) -> UnnamedAppDef:
     """
     Args:
         name: the name of the monarch server job
@@ -37,7 +39,7 @@ def proc_mesh(
         program: path to the binary that the remote process allocator spawns on an allocation request
     """
 
-    appdef = specs.AppDef(name)
+    appdef = UnnamedAppDef()
 
     for mesh in [mesh_spec_from_str(mesh) for mesh in meshes]:
         mesh_role = specs.Role(

--- a/python/monarch/tools/config/__init__.py
+++ b/python/monarch/tools/config/__init__.py
@@ -6,15 +6,32 @@
 
 # pyre-strict
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any, Dict, List, Optional
+
+from torchx.specs import Role
 
 
 NOT_SET: str = "__NOT_SET__"
 
 
 @dataclass
+class UnnamedAppDef:
+    """
+    A TorchX AppDef without a name.
+    """
+
+    roles: List[Role] = field(default_factory=list)
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
 class Config:
+    """
+    All configs needed to schedule a mesh of allocators.
+    """
+
     scheduler: str = NOT_SET
     scheduler_args: dict[str, Any] = field(default_factory=dict)
     workspace: Optional[str] = None
     dryrun: bool = False
+    appdef: UnnamedAppDef = UnnamedAppDef()

--- a/python/monarch/tools/config/defaults.py
+++ b/python/monarch/tools/config/defaults.py
@@ -11,7 +11,7 @@
 from typing import Callable, Optional
 
 from monarch.tools.components import hyperactor
-from monarch.tools.config import Config
+from monarch.tools.config import Config, UnnamedAppDef
 
 from torchx import specs
 from torchx.schedulers import (
@@ -23,7 +23,7 @@ from torchx.schedulers import (
 )
 
 
-def component_fn(scheduler: str) -> Callable[..., specs.AppDef]:
+def component_fn(scheduler: str) -> Callable[..., UnnamedAppDef]:
     """The default TorchX component function for the scheduler"""
     return hyperactor.proc_mesh
 

--- a/python/monarch/tools/mesh_spec.py
+++ b/python/monarch/tools/mesh_spec.py
@@ -9,6 +9,8 @@ import string
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from monarch.tools.config import UnnamedAppDef
+
 from monarch.tools.network import get_sockaddr
 from torchx import specs
 from torchx.specs.api import is_terminal
@@ -69,7 +71,7 @@ def _tag(mesh_name: str, tag_template: str) -> str:
     return string.Template(tag_template).substitute(mesh_name=mesh_name)
 
 
-def tag_as_metadata(mesh_spec: MeshSpec, appdef: specs.AppDef) -> None:
+def tag_as_metadata(mesh_spec: MeshSpec, appdef: UnnamedAppDef) -> None:
     appdef.metadata[_tag(mesh_spec.name, _TAG_HOST_TYPE)] = mesh_spec.host_type
     appdef.metadata[_tag(mesh_spec.name, _TAG_GPUS)] = str(mesh_spec.gpus)
     appdef.metadata[_tag(mesh_spec.name, _TAG_TRANSPORT)] = mesh_spec.transport

--- a/python/tests/tools/config/test_defaults.py
+++ b/python/tests/tools/config/test_defaults.py
@@ -7,10 +7,13 @@
 # pyre-strict
 import unittest
 from pathlib import Path
+from typing import Any, Callable
 
 from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/config/meta:defaults
     defaults,
+    UnnamedAppDef,
 )
+from torchx.specs import AppDef
 from torchx.specs.builders import _create_args_parser
 
 
@@ -33,8 +36,22 @@ class TestDefaults(unittest.TestCase):
 
     def test_default_config_workspace(self) -> None:
         current_working_dir = str(Path.cwd())
-        config = defaults.config("local_cwd", current_working_dir)
+        config = defaults.config(
+            "local_cwd",
+            current_working_dir,
+        )
         self.assertEqual(current_working_dir, config.workspace)
+
+    def test_default_config_appdef(self) -> None:
+        for scheduler, _ in {
+            "mast": {"image": "_DUMMY_FBPKG_:0"},
+            "whatever": {"image": "_DUMMY_FBPKG_:0"},
+            "mast_conda": {},
+        }.items():
+            config = defaults.config(
+                scheduler,
+            )
+            self.assertEqual(UnnamedAppDef(), config.appdef)
 
     def test_default_scheduler_factories(self) -> None:
         # just make sure the common schedulers are present
@@ -44,10 +61,26 @@ class TestDefaults(unittest.TestCase):
     def test_default_component(self) -> None:
         # just make sure there exists a default component for each configured scheduler
         # and that the returned default component is a valid component
+
         for scheduler in defaults.scheduler_factories():
             with self.subTest(scheduler=scheduler):
-                component_fn = defaults.component_fn(scheduler)
+                component_fn: Callable[..., UnnamedAppDef] = defaults.component_fn(
+                    scheduler
+                )
+
+                def _component_fn_wrapper(
+                    component_fn: Callable[..., UnnamedAppDef] = component_fn,
+                    *args: Any,
+                    **kwargs: Any,
+                ) -> AppDef:
+                    name = kwargs.pop("name", None)
+                    unnamed_appdef = component_fn(*args, **kwargs)
+                    return AppDef(
+                        name=name,
+                        roles=unnamed_appdef.roles,
+                        metadata=unnamed_appdef.metadata,
+                    )
 
                 # the following will fail if the component_fn is not a valid torchx component
                 with self.assertRaises(SystemExit):
-                    _create_args_parser(component_fn).parse_args(["--help"])
+                    _create_args_parser(_component_fn_wrapper).parse_args(["--help"])

--- a/python/tests/tools/test_mesh_spec.py
+++ b/python/tests/tools/test_mesh_spec.py
@@ -9,6 +9,8 @@ import json
 import unittest
 from dataclasses import asdict
 
+from monarch.tools.config import UnnamedAppDef
+
 from monarch.tools.mesh_spec import (
     mesh_spec_from_metadata,
     mesh_spec_from_str,
@@ -28,7 +30,7 @@ class TestMeshSpec(unittest.TestCase):
         mesh_spec = MeshSpec(
             name="trainer", num_hosts=2, host_type="gpu.medium", gpus=2
         )
-        appdef = specs.AppDef(name=UNUSED)
+        appdef = UnnamedAppDef()
         tag_as_metadata(mesh_spec, appdef)
 
         self.assertDictEqual(


### PR DESCRIPTION
Summary:
use appdef as the source of truth
even that, the API needs to be revisited as the input of get and the input of
create are different.

Differential Revision: D78760248


