### PR TITLE
Match chrono version between hyperactor_mesh and hyperactor

### DIFF
--- a/hyper/Cargo.toml
+++ b/hyper/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [dependencies]
 anyhow = "1.0.95"
 async-trait = "0.1.86"
-chrono = { version = "=0.4.39", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.41", features = ["clock", "serde", "std"], default-features = false }
 clap = { version = "4.5.30", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 console = "0.15.7"
 hyperactor = { path = "../hyperactor" }


### PR DESCRIPTION
Summary:
OSS wheel builds currently fails due to differing chrono versions. Since `hyper/Cargo.toml` is manually maintained, we bump this up to match the version generated by `arc autocargo`.


Also removes the testing in the wheel creation phase which has been flaky.

Differential Revision: D78899181


