### PR TITLE
at least show something to users during allocation

### DIFF
--- a/python/monarch/tools/mesh_spec.py
+++ b/python/monarch/tools/mesh_spec.py
@@ -41,6 +41,7 @@ class MeshSpec:
     transport: str = "tcp"
     port: int = DEFAULT_REMOTE_ALLOCATOR_PORT
     hostnames: list[str] = field(default_factory=list)
+    state: specs.AppState = specs.AppState.UNSUBMITTED
 
     def server_addrs(
         self, transport: Optional[str] = None, port: Optional[int] = None

--- a/python/tests/tools/test_mesh_spec.py
+++ b/python/tests/tools/test_mesh_spec.py
@@ -107,7 +107,8 @@ class TestMeshSpec(unittest.TestCase):
     "n1",
     "n2",
     "n3"
-  ]
+  ],
+  "state": 0
 }
 """
         self.assertEqual(expected.strip("\n"), json.dumps(asdict(mesh_spec), indent=2))


### PR DESCRIPTION
Summary:
We have moved all systems logs to files to avoid spamming user logs.
But for calls like allocation, it can take a long while. Print progress logs so
that users are aware of the progress.

Differential Revision: D78951566


