### PR TITLE
Remove none_throws in event_loop.py

### DIFF
--- a/python/monarch/_src/actor/event_loop.py
+++ b/python/monarch/_src/actor/event_loop.py
@@ -14,7 +14,7 @@ import logging
 import threading
 from typing import Optional
 
-from libfb.py.pyre import none_throws
+from pyre_extensions import none_throws
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Summary: Adding `"//libfb/py/pyre:pyre",` broke OSS, remove that import

Differential Revision: D78988725


