### PR TITLE
: monarch: actor: fix mesh trait slice bug

### DIFF
--- a/python/monarch/_src/actor/shape.py
+++ b/python/monarch/_src/actor/shape.py
@@ -67,7 +67,12 @@ class MeshTrait(ABC):
                     start, stop, slice_stride = e.indices(size)
                     offset += start * stride
                     names.append(name)
-                    sizes.append((stop - start) // slice_stride)
+                    # The number of elems in `start..stop` with step
+                    # `slice_stride`. This is:
+                    #    ⌈(stop - start) /slice_stride⌉
+                    # — the number of stride steps that fit in the
+                    # half-open interval.
+                    sizes.append((stop - start + slice_stride - 1) // slice_stride)
                     strides.append(slice_stride * stride)
                 else:
                     if e >= size or e < 0:


### PR DESCRIPTION
Summary:
this is a bugfix, same as D78315005.

in `slice()` the length of a strided range is computed using truncating division where it should be ceiling division. the symptoms are e.g. slicing `0..7` with `step 2` gives `[0, 2, 4]` (sizes `[3]`) but clearly the correctly selected indices are `[0, 2, 4, 6]` (sizes `[4]`).

Differential Revision: D79011033


