### PR TITLE
Convert dataclasses mutable default values to use default_factory

### DIFF
--- a/python/monarch/tools/config/__init__.py
+++ b/python/monarch/tools/config/__init__.py
@@ -34,4 +34,4 @@ class Config:
     scheduler_args: dict[str, Any] = field(default_factory=dict)
     workspace: Optional[str] = None
     dryrun: bool = False
-    appdef: UnnamedAppDef = UnnamedAppDef()
+    appdef: UnnamedAppDef = field(default_factory=UnnamedAppDef)


### PR DESCRIPTION
Summary:
As of [Python 3.11](https://docs.python.org/3.11/whatsnew/3.11.html#dataclasses), dataclasses now only allow defaults that are hashable. Using mutable (non-hashable) default values under Python 3.11+ will cause a runtime error:

```
ValueError: mutable default <class 'problematic.ClassName'> for field <field> is not allowed: use default_factory
```

This codemod attempts to automatically convert mutable defaults to use `default_factory`

NOTE: The change is not semantically equivalent to before the change. Before, all dataclass instances with a mutable default value were sharing the same instance. This change results each dataclass instance using a new instance of the mutable value. It is likely that the before state was a latent bug, but it's still a behavior change!

Differential Revision: D79097490


