### PR TITLE
Avoid panic in Drop for PythonActorMesh

### DIFF
--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -383,10 +383,11 @@ impl PythonActorMeshRef {
 
 impl Drop for PythonActorMesh {
     fn drop(&mut self) {
-        tracing::info!(
-            "Dropping PythonActorMesh: {}",
-            self.inner.borrow().unwrap().name()
-        );
+        if let Ok(mesh) = self.inner.borrow() {
+            tracing::info!("Dropping PythonActorMesh: {}", mesh.name());
+        } else {
+            tracing::info!("Dropping stopped PythonActorMesh");
+        }
         self.monitor.abort();
     }
 }


### PR DESCRIPTION
Summary:
There was a panic happening whenever a previously stopped proc mesh was
being dropped:
```
thread '<unnamed>' panicked at fbcode/monarch/monarch_hyperactor/src/actor_mesh.rs:394:33:
called `Result::unwrap()` on an `Err` value: EmptyCellError
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::result::unwrap_failed
   3: <monarch_hyperactor::actor_mesh::PythonActorMesh as core::ops::drop::Drop>::drop
   4: <pyo3::pycell::impl_::PyClassObject<monarch_hyperactor::actor_mesh::PythonActorMesh> as pyo3::pycell::impl_::PyClassObjectLayout<monarch_hyperactor::actor_mesh::PythonActorMesh>>::tp_dealloc
```

This was luckily ignored by pytest and considered a test pass, but it still messes up logs
and raises a pyo3.Panic exception.
It happened because the `stop()` method was taking the inner reference, so `borrow().unwrap()`
would panic.

Differential Revision: D79200358


