### PR TITLE
Add stderr string to ProcStopReason::Exited

### DIFF
--- a/hyperactor_mesh/src/alloc.rs
+++ b/hyperactor_mesh/src/alloc.rs
@@ -171,8 +171,8 @@ impl fmt::Display for ProcState {
 pub enum ProcStopReason {
     /// The proc stopped gracefully, e.g., with exit code 0.
     Stopped,
-    /// The proc exited with the provided error code.
-    Exited(i32),
+    /// The proc exited with the provided error code and stderr
+    Exited(i32, String),
     /// The proc was killed. The signal number is indicated;
     /// the flags determines whether there was a core dump.
     Killed(i32, bool),
@@ -189,7 +189,13 @@ impl fmt::Display for ProcStopReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Stopped => write!(f, "stopped"),
-            Self::Exited(code) => write!(f, "exited with code {}", code),
+            Self::Exited(code, stderr) => {
+                if stderr.is_empty() {
+                    write!(f, "exited with code {}", code)
+                } else {
+                    write!(f, "exited with code {}: {}", code, stderr)
+                }
+            }
             Self::Killed(signal, dumped) => {
                 write!(f, "killed with signal {} (core dumped={})", signal, dumped)
             }


### PR DESCRIPTION
Summary: Adding a string to the ProcStopReason::Exited as a way to stream back the logs when an allocation fails remotely. Open to feedback if there is a better way to stream back the stderr logs - since here we get duplicate logs if its running locally.

Reviewed By: mariusae

Differential Revision: D78937427


