### PR TITLE
Disable Meta_TLS to unblock diff time tests

### DIFF
--- a/hyperactor/benches/channel_benchmarks.rs
+++ b/hyperactor/benches/channel_benchmarks.rs
@@ -44,7 +44,6 @@ fn bench_message_sizes(c: &mut Criterion) {
     let transports = vec![
         ("local", ChannelTransport::Local),
         ("tcp", ChannelTransport::Tcp),
-        ("metatls", ChannelTransport::MetaTls),
         ("unix", ChannelTransport::Unix),
     ];
 


### PR DESCRIPTION
Summary:
Unblocks diff time checks

When running test locally all communication channels finish in under 10s for any message size, Meta TLS does not finish smallest benchmark in time within a minute

There should be a follow up to understand why MetaTLS is not finishing within timeout

Reviewed By: vidhyav

Differential Revision: D79271339


