### PR TITLE
Pass mesh id in cast message's header

### DIFF
--- a/hyperactor/src/attrs.rs
+++ b/hyperactor/src/attrs.rs
@@ -511,7 +511,7 @@ macro_rules! const_ascii_lowercase {
 /// declare_attrs! {
 ///     /// Documentation for the key (default visibility).
 ///     attr KEY_NAME: Type = default_value;
-///     
+///
 ///     /// Another key (default value is optional)
 ///     pub attr ANOTHER_KEY: AnotherType;
 /// }

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -145,6 +145,7 @@ pub fn supervise_undeliverable_messages(
                         "message not delivered: {}",
                         envelope
                     )),
+                    message_headers: Some(envelope.headers().clone()),
                 })
                 .is_err()
             {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -956,6 +956,7 @@ impl<A: Actor> Instance<A> {
                 parent.send_supervision_event_or_crash(ActorSupervisionEvent {
                     actor_id: self.cell.actor_id().clone(),
                     actor_status: actor_status.clone(),
+                    message_headers: None,
                 });
             }
         } else {
@@ -968,6 +969,7 @@ impl<A: Actor> Instance<A> {
                 self.proc.handle_supervision_event(ActorSupervisionEvent {
                     actor_id: self.cell.actor_id().clone(),
                     actor_status: actor_status.clone(),
+                    message_headers: None,
                 })
             }
         }

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -10,19 +10,25 @@
 
 use std::fmt::Debug;
 
+use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 
 use crate as hyperactor; // for macros
 use crate::Named;
 use crate::actor::ActorStatus;
+use crate::attrs::Attrs;
 use crate::reference::ActorId;
 
 /// This is the local actor supervision event. Child actor will propagate this event to its parent.
-#[derive(Clone, Debug, Serialize, Deserialize, Named)]
+#[derive(Clone, Debug, Derivative, Serialize, Deserialize, Named)]
+#[derivative(PartialEq, Eq)]
 pub struct ActorSupervisionEvent {
     /// The actor id of the child actor where the event is triggered.
     pub actor_id: ActorId,
     /// Status of the child actor.
     pub actor_status: ActorStatus,
+    /// If this event is associated with a message, the message headers.
+    #[derivative(PartialEq = "ignore")]
+    pub message_headers: Option<Attrs>,
 }


### PR DESCRIPTION
Summary:
During casting, when a message is sent to a comm actor, `MessageEnvelope.dest` is comm actor ID, not actor mesh’s actor ID. So the supervision event was raised for [comm actor](https://fburl.com/code/7q3npujw), not actor mesh as we would expect.

We cannot simply change `MessageEnvelope.dest` to dest actor because it is used by mailbox to find comm actor’s port.: https://fburl.com/code/4lelgw8w

To quickly work around the problem in order to unblock cast integration, this diff adds the mesh's name into message header, so it can be retrieved by `supervise_undeliverable_messages`.

Differential Revision: D79100206


