### PR TITLE
ndslice: make iterators owned (#713)

### DIFF
--- a/hyperactor_mesh/src/mesh.rs
+++ b/hyperactor_mesh/src/mesh.rs
@@ -55,7 +55,7 @@ pub trait Mesh {
 /// An iterator over the nodes of a mesh.
 pub struct MeshIter<'a, M: Mesh + ?Sized> {
     mesh: &'a M,
-    slice_iter: SliceIterator<'a>,
+    slice_iter: SliceIterator,
 }
 
 impl<M: Mesh> Iterator for MeshIter<'_, M> {

--- a/ndslice/src/shape.rs
+++ b/ndslice/src/shape.rs
@@ -232,7 +232,7 @@ impl Shape {
 /// `[2, 2, 8]` shape.
 pub struct SelectIterator<'a> {
     shape: &'a Shape,
-    iter: DimSliceIterator<'a>,
+    iter: DimSliceIterator,
 }
 
 impl<'a> Iterator for SelectIterator<'a> {

--- a/ndslice/src/view.rs
+++ b/ndslice/src/view.rs
@@ -176,7 +176,7 @@ impl Extent {
     pub fn iter(&self) -> ExtentIterator {
         ExtentIterator {
             extent: self,
-            pos: CartesianIterator::new(self.sizes()),
+            pos: CartesianIterator::new(self.sizes().to_vec()),
         }
     }
 }
@@ -197,7 +197,7 @@ impl std::fmt::Display for Extent {
 /// An iterator for points in an extent.
 pub struct ExtentIterator<'a> {
     extent: &'a Extent,
-    pos: CartesianIterator<'a>,
+    pos: CartesianIterator,
 }
 
 impl<'a> Iterator for ExtentIterator<'a> {
@@ -412,12 +412,12 @@ impl View {
 }
 
 /// The iterator over views.
-pub struct ViewIterator<'a> {
-    extent: Extent,         // Note that `extent` and...
-    pos: SliceIterator<'a>, // ... `pos` share the same `Slice`.
+pub struct ViewIterator {
+    extent: Extent,     // Note that `extent` and...
+    pos: SliceIterator, // ... `pos` share the same `Slice`.
 }
 
-impl<'a> Iterator for ViewIterator<'a> {
+impl Iterator for ViewIterator {
     type Item = (Point, usize);
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
Summary:

References make them needlessly difficult to compose in practice. For example, it is very hard to build an iterator that composes on slice iterators, without creating an explicit intermediate object first.

Reviewed By: shayne-fletcher

Differential Revision: D79400562


