### PR TITLE
hyperactor_mesh: wire up mesh-managed actors to the global router (#732)

### DIFF
--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -71,7 +71,7 @@ use std::sync::OnceLock;
 /// This is definitely a "good enough for now" solution; in the future,
 /// we'll likely have some form of truly global registration for meshes,
 /// also benefitting tooling, etc.
-fn global_router() -> &'static MailboxRouter {
+pub(crate) fn global_router() -> &'static MailboxRouter {
     static GLOBAL_ROUTER: OnceLock<MailboxRouter> = OnceLock::new();
     GLOBAL_ROUTER.get_or_init(MailboxRouter::new)
 }


### PR DESCRIPTION
Summary:

When a ProcMesh is created, it is wired into a process-global router, which is used as a fallback for the mesh itself. This is how multiple meshes discover and talk to each other.

However if an actor *in* a mesh creates its own (child) ProcMesh, it is not mututally routable with that child mesh.

This change wires up the various bindings to ensure that they are.

Note that currently this only makes an *actor* that owns a procmesh mutually reachable with the procmesh it creates; it does not yet allow (direct) routing between proc meshes managed by different actors.

Reviewed By: shayne-fletcher, zdevito

Differential Revision: D79478197
