### PR TITLE
use string edit distance for aggregation

### DIFF
--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -59,7 +59,6 @@ nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "
 pin-project = "1.1.10"
 preempt_rwlock = { version = "0.0.0", path = "../preempt_rwlock" }
 rand = { version = "0.8", features = ["small_rng"] }
-regex = "1.11.1"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "unbounded_depth"] }

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -612,41 +612,42 @@ async def test_actor_log_streaming() -> None:
         # Has a leading context so we can distinguish between streamed log and
         # the log directly printed by the child processes as they share the same stdout/stderr
         assert not re.search(
-            r"processes.*no print streaming", stdout_content
+            r"similar log lines.*no print streaming", stdout_content
         ), stdout_content
         assert not re.search(
-            r"processes.*no print streaming", stderr_content
+            r"similar log lines.*no print streaming", stderr_content
         ), stderr_content
         assert not re.search(
-            r"processes.*no log streaming", stdout_content
+            r"similar log lines.*no log streaming", stdout_content
         ), stdout_content
         assert not re.search(
-            r"processes.*no log streaming", stderr_content
+            r"similar log lines.*no log streaming", stderr_content
         ), stderr_content
         assert not re.search(
-            r"processes.*no log streaming due to level mismatch", stdout_content
+            r"similar log lines.*no log streaming due to level mismatch", stdout_content
         ), stdout_content
         assert not re.search(
-            r"processes.*no log streaming due to level mismatch", stderr_content
+            r"similar log lines.*no log streaming due to level mismatch", stderr_content
         ), stderr_content
 
         assert re.search(
-            r"processes.*has print streaming", stdout_content
+            r"similar log lines.*has print streaming", stdout_content
         ), stdout_content
         assert not re.search(
-            r"processes.*has print streaming", stderr_content
+            r"similar log lines.*has print streaming", stderr_content
         ), stderr_content
         assert re.search(
-            r"processes.*has print streaming too", stdout_content
+            r"similar log lines.*has print streaming too", stdout_content
         ), stdout_content
         assert not re.search(
-            r"processes.*has print streaming too", stderr_content
+            r"similar log lines.*has print streaming too", stderr_content
         ), stderr_content
         assert not re.search(
-            r"processes.*log streaming as level matched", stdout_content
+            r"similar log lines.*log streaming as level matched", stdout_content
         ), stdout_content
         assert re.search(
-            r"processes.*log streaming as level matched", stderr_content
+            r"similar log lines.*log streaming as level matched",
+            stderr_content,
         ), stderr_content
 
     finally:
@@ -723,14 +724,18 @@ async def test_logging_option_defaults() -> None:
         os.unlink(stderr_path)
 
         # Assertions on the captured output
-        assert re.search(r"processes.*print streaming", stdout_content), stdout_content
+        assert re.search(
+            r"similar log lines.*print streaming", stdout_content
+        ), stdout_content
         assert not re.search(
-            r"processes.*print streaming", stderr_content
+            r"similar log lines.*print streaming", stderr_content
         ), stderr_content
         assert not re.search(
-            r"processes.*log streaming", stdout_content
+            r"similar log lines.*log streaming", stdout_content
         ), stdout_content
-        assert re.search(r"processes.*log streaming", stderr_content), stderr_content
+        assert re.search(
+            r"similar log lines.*log streaming", stderr_content
+        ), stderr_content
 
     finally:
         # Ensure file descriptors are restored even if something goes wrong


### PR DESCRIPTION
Summary:
instead of just dedup intergers, we switch to use edit distance to
dedup arbitrary log lines.

Differential Revision: D79492339


