### PR TITLE
: selection: reify_view -> reify_slice

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -39,7 +39,7 @@ use ndslice::ShapeError;
 use ndslice::SliceError;
 use ndslice::selection;
 use ndslice::selection::EvalOpts;
-use ndslice::selection::ReifyView;
+use ndslice::selection::ReifySlice;
 use ndslice::selection::normal;
 use serde::Deserialize;
 use serde::Serialize;
@@ -118,7 +118,7 @@ where
     // Casting to `*`?
     let sel_of_root = if selection::normalize(sel_of_sliced) == normal::NormalizedSelection::True {
         // Reify this view into base.
-        root_slice.reify_view(sliced_shape.slice())?
+        root_slice.reify_slice(sliced_shape.slice())?
     } else {
         // No, fall back on `of_ranks`.
         let ranks = sel_of_sliced

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -58,7 +58,7 @@ use monarch_tensor_worker::AssignRankMessage;
 use monarch_tensor_worker::WorkerActor;
 use ndslice::Slice;
 use ndslice::selection;
-use ndslice::selection::ReifyView;
+use ndslice::selection::ReifySlice;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use tokio::sync::Mutex;
@@ -827,7 +827,7 @@ impl Handler<ClientToControllerMessage> for MeshControllerActor {
     ) -> anyhow::Result<()> {
         match message {
             ClientToControllerMessage::Send { slices, message } => {
-                let sel = self.workers().shape().slice().reify_views(slices)?;
+                let sel = self.workers().shape().slice().reify_slices(slices)?;
                 self.workers().cast(sel, message)?;
             }
             ClientToControllerMessage::Node {


### PR DESCRIPTION
Summary: with type `View` now in the code base, i figure `ReifyView` and `reify_view` should be renamed `ReifySlice` and `reify_slice` to get out in front of the inevitable confusion.

Differential Revision: D79555875


