### PR TITLE
: mailbox: undeliverable: custom_monitored_return_handle

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -127,6 +127,7 @@ mod undeliverable;
 /// For [`Undeliverable`], a message type for delivery failures.
 pub use undeliverable::Undeliverable;
 pub use undeliverable::UndeliverableMessageError;
+pub use undeliverable::custom_monitored_return_handle;
 pub use undeliverable::monitored_return_handle; // TODO: Audit
 pub use undeliverable::supervise_undeliverable_messages;
 /// For [`MailboxAdminMessage`], a message type for mailbox administration.

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -193,7 +193,7 @@ impl ProcMesh {
         }
         router
             .clone()
-            .serve(router_rx, mailbox::monitored_return_handle());
+            .serve(router_rx, mailbox::custom_monitored_return_handle("router"));
 
         // Set up a client proc for the mesh itself, so that we can attach ourselves
         // to it, and communicate with the agents. We wire it into the same router as
@@ -207,9 +207,10 @@ impl ProcMesh {
             client_proc_id.clone(),
             BoxedMailboxSender::new(router.clone()),
         );
-        client_proc
-            .clone()
-            .serve(client_rx, mailbox::monitored_return_handle());
+        client_proc.clone().serve(
+            client_rx,
+            mailbox::custom_monitored_return_handle("client proc"),
+        );
         router.bind(client_proc_id.clone().into(), client_proc_addr.clone());
 
         // Bind this router to the global router, to enable cross-mesh routing.


### PR DESCRIPTION
Summary: new function `custom_monitored_return_handle` to replace the few remaining `monitored_return_handle` in order that we get better insight into where they still exist.

Differential Revision: D79593009


