### PR TITLE
mesh: extent/view based allocation

### DIFF
--- a/hyperactor_mesh/benches/main.rs
+++ b/hyperactor_mesh/benches/main.rs
@@ -18,9 +18,9 @@ use hyperactor_mesh::actor_mesh::RootActorMesh;
 use hyperactor_mesh::alloc::AllocSpec;
 use hyperactor_mesh::alloc::Allocator;
 use hyperactor_mesh::alloc::LocalAllocator;
+use hyperactor_mesh::extent;
 use hyperactor_mesh::selection::dsl::all;
 use hyperactor_mesh::selection::dsl::true_;
-use hyperactor_mesh::shape;
 
 mod bench_actor;
 use bench_actor::BenchActor;
@@ -39,10 +39,9 @@ fn bench_actor_scaling(c: &mut Criterion) {
         group.bench_function(BenchmarkId::from_parameter(host_count), |b| {
             let mut b = b.to_async(Runtime::new().unwrap());
             b.iter_custom(|iters| async move {
-                let shape = shape! {  hosts=host_count, gpus=8 };
                 let alloc = LocalAllocator
                     .allocate(AllocSpec {
-                        shape: shape.clone(),
+                        extent: extent!(hosts = host_count, gpus = 8),
                         constraints: Default::default(),
                     })
                     .await

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -27,9 +27,9 @@ use hyperactor_mesh::alloc::AllocSpec;
 use hyperactor_mesh::alloc::Allocator;
 use hyperactor_mesh::alloc::LocalAllocator;
 use hyperactor_mesh::comm::multicast::CastInfo;
+use hyperactor_mesh::extent;
 use hyperactor_mesh::selection::dsl::all;
 use hyperactor_mesh::selection::dsl::true_;
-use hyperactor_mesh::shape;
 use ndslice::selection::selection_from;
 use serde::Deserialize;
 use serde::Serialize;
@@ -228,7 +228,7 @@ async fn main() -> Result<ExitCode> {
     let group_size = 5;
     let alloc = LocalAllocator
         .allocate(AllocSpec {
-            shape: shape! {replica = group_size},
+            extent: extent! {replica = group_size},
             constraints: Default::default(),
         })
         .await?;

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -27,7 +27,7 @@ use hyperactor_mesh::ProcMesh;
 use hyperactor_mesh::alloc::AllocSpec;
 use hyperactor_mesh::alloc::Allocator;
 use hyperactor_mesh::alloc::LocalAllocator;
-use hyperactor_mesh::shape;
+use hyperactor_mesh::extent;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -106,7 +106,7 @@ impl Actor for SieveActor {
 async fn main() -> Result<ExitCode> {
     let alloc = LocalAllocator
         .allocate(AllocSpec {
-            shape: shape! { replica = 1 },
+            extent: extent! { replica = 1 },
             constraints: Default::default(),
         })
         .await?;

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -461,6 +461,7 @@ pub(crate) mod test_util {
     use hyperactor::Context;
     use hyperactor::Handler;
     use hyperactor::PortRef;
+    use ndslice::extent;
 
     use super::*;
     use crate::comm::multicast::CastInfo;
@@ -590,8 +591,6 @@ pub(crate) mod test_util {
             // The actor creates a mesh.
             use std::sync::Arc;
 
-            use ndslice::shape;
-
             use crate::alloc::AllocSpec;
             use crate::alloc::Allocator;
             use crate::alloc::LocalAllocator;
@@ -599,7 +598,7 @@ pub(crate) mod test_util {
             let mut allocator = LocalAllocator;
             let alloc = allocator
                 .allocate(AllocSpec {
-                    shape: shape! { replica = 1 },
+                    extent: extent! { replica = 1 },
                     constraints: Default::default(),
                 })
                 .await
@@ -652,7 +651,7 @@ mod tests {
         ($allocator:expr_2021) => {
             use std::assert_matches::assert_matches;
 
-            use ndslice::shape;
+            use ndslice::extent;
             use $crate::alloc::AllocSpec;
             use $crate::alloc::Allocator;
             use $crate::assign::Ranks;
@@ -674,11 +673,11 @@ mod tests {
 
                 hyperactor_telemetry::initialize_logging(hyperactor::clock::ClockKind::default());
 
-                use ndslice::shape;
+                use ndslice::extent;
 
                 let alloc = $allocator
                     .allocate(AllocSpec {
-                        shape: shape! { replica = 1 },
+                        extent: extent! { replica = 1 },
                         constraints: Default::default(),
                     })
                     .await
@@ -695,7 +694,7 @@ mod tests {
             async fn test_basic() {
                 let alloc = $allocator
                     .allocate(AllocSpec {
-                        shape: shape! { replica = 4 },
+                        extent: extent!(replica = 4),
                         constraints: Default::default(),
                     })
                     .await
@@ -720,7 +719,7 @@ mod tests {
 
                 let alloc = $allocator
                     .allocate(AllocSpec {
-                        shape: shape! { replica = 2  },
+                        extent: extent!(replica = 2),
                         constraints: Default::default(),
                     })
                     .await
@@ -755,7 +754,7 @@ mod tests {
                 const Z: usize = 3;
                 let alloc = $allocator
                     .allocate(AllocSpec {
-                        shape: shape! { x = X, y = Y, z = Z },
+                        extent: extent!(x = X, y = Y, z = Z),
                         constraints: Default::default(),
                     })
                     .await
@@ -798,7 +797,7 @@ mod tests {
             async fn test_cast() {
                 let alloc = $allocator
                     .allocate(AllocSpec {
-                        shape: shape! { replica = 2, host = 2, gpu = 8 },
+                        extent: extent!(replica = 2, host = 2, gpu = 8),
                         constraints: Default::default(),
                     })
                     .await
@@ -838,7 +837,7 @@ mod tests {
                         // Sizes intentionally small to keep the time
                         // required for this test in the process case
                         // reasonable (< 60s).
-                        shape: shape! { replica = 2, host = 2, gpu = 8 },
+                        extent: extent!(replica = 2, host = 2, gpu = 8),
                         constraints: Default::default(),
                     })
                     .await
@@ -868,7 +867,7 @@ mod tests {
                 for _ in 0..2 {
                     let alloc = $allocator
                         .allocate(AllocSpec {
-                            shape: shape! { replica = 1 },
+                            extent: extent!(replica = 1),
                             constraints: Default::default(),
                         })
                         .await
@@ -911,11 +910,11 @@ mod tests {
                 use $crate::comm::test_utils::TestActorParams as CastTestActorParams;
                 use $crate::comm::test_utils::TestMessage as CastTestMessage;
 
-                let shape = shape! {replica = 4, host = 4, gpu = 4 };
-                let num_actors = shape.slice().len();
+                let extent = extent!(replica = 4, host = 4, gpu = 4);
+                let num_actors = extent.len();
                 let alloc = $allocator
                     .allocate(AllocSpec {
-                        shape,
+                        extent,
                         constraints: Default::default(),
                     })
                     .await
@@ -938,7 +937,7 @@ mod tests {
             async fn test_delivery_failure() {
                 let alloc = $allocator
                     .allocate(AllocSpec {
-                        shape: shape! { replica = 1  },
+                        extent: extent!(replica = 1 ),
                         constraints: Default::default(),
                     })
                     .await
@@ -966,7 +965,7 @@ mod tests {
             async fn test_send_with_headers() {
                 let alloc = $allocator
                     .allocate(AllocSpec {
-                        shape: shape! { replica = 1  },
+                        extent: extent!(replica = 1 ),
                         constraints: Default::default(),
                     })
                     .await
@@ -1025,7 +1024,7 @@ mod tests {
 
             let alloc = LocalAllocator
                 .allocate(AllocSpec {
-                    shape: shape! { replica = 2  },
+                    extent: extent!(replica = 2),
                     constraints: Default::default(),
                 })
                 .await
@@ -1092,7 +1091,7 @@ mod tests {
 
             let alloc = LocalAllocator
                 .allocate(AllocSpec {
-                    shape: shape! { replica = 1  },
+                    extent: extent!(replica = 1),
                     constraints: Default::default(),
                 })
                 .await
@@ -1158,7 +1157,7 @@ mod tests {
 
             let alloc = LocalAllocator
                 .allocate(AllocSpec {
-                    shape: shape! { replica = 2  },
+                    extent: extent!(replica = 2),
                     constraints: Default::default(),
                 })
                 .await
@@ -1241,10 +1240,10 @@ mod tests {
             // One rank is enough for this test, because the timeout failure
             // occurred in the `client->1st comm actor` channel, and thus will
             // not be sent further to the rest of the network.
-            let shape = shape! {replica = 1 };
+            let extent = extent! {replica = 1 };
             let alloc = process_allocator()
                 .allocate(AllocSpec {
-                    shape,
+                    extent,
                     constraints: Default::default(),
                 })
                 .await

--- a/hyperactor_mesh/src/alloc/sim.rs
+++ b/hyperactor_mesh/src/alloc/sim.rs
@@ -16,7 +16,7 @@ use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::mailbox::MailboxServerHandle;
 use hyperactor::proc::Proc;
-use ndslice::Shape;
+use ndslice::view::Extent;
 
 use super::ProcStopReason;
 use crate::alloc::Alloc;
@@ -93,8 +93,8 @@ impl Alloc for SimAlloc {
         self.inner.next().await
     }
 
-    fn shape(&self) -> &Shape {
-        self.inner.shape()
+    fn extent(&self) -> &Extent {
+        self.inner.extent()
     }
 
     fn world_id(&self) -> &WorldId {

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -37,6 +37,7 @@ pub use comm::CommActor;
 pub use dashmap;
 pub use hyperactor_mesh_macros::sel;
 pub use mesh::Mesh;
+pub use ndslice::extent;
 pub use ndslice::sel_from_shape;
 pub use ndslice::selection;
 pub use ndslice::shape;

--- a/hyperactor_mesh/src/reference.rs
+++ b/hyperactor_mesh/src/reference.rs
@@ -206,7 +206,8 @@ mod tests {
     use hyperactor::PortRef;
     use hyperactor::Unbind;
     use hyperactor_mesh_macros::sel;
-    use ndslice::shape;
+    use ndslice::Extent;
+    use ndslice::extent;
 
     use super::*;
     use crate::Mesh;
@@ -217,8 +218,8 @@ mod tests {
     use crate::alloc::Allocator;
     use crate::alloc::LocalAllocator;
 
-    fn shape() -> Shape {
-        shape! { replica = 4 }
+    fn extent() -> Extent {
+        extent!(replica = 4)
     }
 
     #[derive(Debug, Serialize, Deserialize, Named, Clone, Bind, Unbind)]
@@ -276,14 +277,14 @@ mod tests {
     async fn test_inter_mesh_ping_pong() {
         let alloc_ping = LocalAllocator
             .allocate(AllocSpec {
-                shape: shape(),
+                extent: extent(),
                 constraints: Default::default(),
             })
             .await
             .unwrap();
         let alloc_pong = LocalAllocator
             .allocate(AllocSpec {
-                shape: shape(),
+                extent: extent(),
                 constraints: Default::default(),
             })
             .await

--- a/hyperactor_mesh/test/process_allocator_cleanup/process_allocator_test_bin.rs
+++ b/hyperactor_mesh/test/process_allocator_cleanup/process_allocator_test_bin.rs
@@ -16,7 +16,7 @@ use hyperactor_mesh::alloc::AllocSpec;
 use hyperactor_mesh::alloc::Allocator;
 use hyperactor_mesh::alloc::ProcState;
 use hyperactor_mesh::alloc::ProcessAllocator;
-use ndslice::shape;
+use ndslice::extent;
 use tokio::process::Command;
 
 fn emit_proc_state(state: &ProcState) {
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create an allocation with 4 child processes
     let mut alloc = allocator
         .allocate(AllocSpec {
-            shape: shape! { replica = 4 },
+            extent: extent! { replica = 4 },
             constraints: AllocConstraints::default(),
         })
         .await?;

--- a/hyperactor_mesh/test/remote_process_alloc.rs
+++ b/hyperactor_mesh/test/remote_process_alloc.rs
@@ -22,7 +22,7 @@ use hyperactor_mesh::alloc::ProcState;
 use hyperactor_mesh::alloc::remoteprocess::MockRemoteProcessAllocInitializer;
 use hyperactor_mesh::alloc::remoteprocess::RemoteProcessAlloc;
 use hyperactor_mesh::alloc::remoteprocess::RemoteProcessAllocHost;
-use hyperactor_mesh::shape;
+use hyperactor_mesh::extent;
 
 // Spawn 2 proc_meshes each with 2 hosts
 #[derive(Parser, Debug)]
@@ -89,7 +89,7 @@ async fn main() {
 
         let mut alloc = RemoteProcessAlloc::new(
             AllocSpec {
-                shape: shape!(host = hosts_per_proc_mesh, gpu = 1),
+                extent: extent!(host = hosts_per_proc_mesh, gpu = 1),
                 constraints: Default::default(),
             },
             WorldId("test_world_id".to_string()),

--- a/monarch_hyperactor/src/bin/process_allocator/common.rs
+++ b/monarch_hyperactor/src/bin/process_allocator/common.rs
@@ -74,7 +74,7 @@ mod tests {
     use hyperactor_mesh::alloc;
     use hyperactor_mesh::alloc::Alloc;
     use hyperactor_mesh::alloc::remoteprocess;
-    use ndslice::shape;
+    use ndslice::extent;
 
     use super::*;
 
@@ -115,7 +115,7 @@ mod tests {
 
         let spec = alloc::AllocSpec {
             // NOTE: x cannot be more than 1 since we created a single process-allocator server instance!
-            shape: shape! { x=1, y=4 },
+            extent: extent! { x=1, y=4 },
             constraints: Default::default(),
         };
 
@@ -140,7 +140,7 @@ mod tests {
         .unwrap();
 
         // make sure we accounted for `world_size` number of Created and Stopped proc states
-        let world_size = spec.shape.slice().iter().count();
+        let world_size = spec.extent.num_ranks();
         let mut created_ranks: HashSet<usize> = HashSet::new();
         let mut stopped_ranks: HashSet<usize> = HashSet::new();
 
@@ -181,7 +181,7 @@ mod tests {
 
         let spec = alloc::AllocSpec {
             // NOTE: x cannot be more than 1 since we created a single process-allocator server instance!
-            shape: shape! { x=1, y=4 },
+            extent: extent! { x=1, y=4 },
             constraints: Default::default(),
         };
 
@@ -239,7 +239,7 @@ mod tests {
 
         let spec = alloc::AllocSpec {
             // NOTE: x cannot be more than 1 since we created a single process-allocator server instance!
-            shape: shape! { x=1, y=4 },
+            extent: extent! { x=1, y=4 },
             constraints: Default::default(),
         };
 
@@ -318,7 +318,7 @@ mod tests {
 
         let spec = alloc::AllocSpec {
             // NOTE: x cannot be more than 1 since we created a single process-allocator server instance!
-            shape: shape! { x=1, y=4 },
+            extent: extent! { x=1, y=4 },
             constraints: Default::default(),
         };
 
@@ -346,7 +346,7 @@ mod tests {
         // Ensure the process starts. Since the command is "sleep", it should
         // start without stopping.
         // make sure we accounted for `world_size` number of Created and Stopped proc states
-        let world_size = spec.shape.slice().iter().count();
+        let world_size = spec.extent.num_ranks();
         let mut created_ranks: HashSet<usize> = HashSet::new();
 
         while created_ranks.len() < world_size {

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -91,7 +91,7 @@ impl WorkspaceShape {
         Ok(new_shape)
     }
 
-    /// Return a new shape that containts all ranks that share the same workspace with the given "owning" rank.
+    /// Return a new shape that contains all ranks that share the same workspace with the given "owning" rank.
     ///
     /// # Errors
     ///
@@ -367,6 +367,7 @@ mod tests {
     use hyperactor_mesh::alloc::Allocator;
     use hyperactor_mesh::alloc::local::LocalAllocator;
     use hyperactor_mesh::proc_mesh::ProcMesh;
+    use ndslice::extent;
     use ndslice::shape;
     use tempfile::TempDir;
     use tokio::fs;
@@ -455,7 +456,7 @@ mod tests {
         // Set up actor mesh with CodeSyncManager actors
         let alloc = LocalAllocator
             .allocate(AllocSpec {
-                shape: shape! { replica = 2 },
+                extent: extent! { replica = 2 },
                 constraints: Default::default(),
             })
             .await?;

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -439,7 +439,7 @@ mod tests {
     use hyperactor_mesh::alloc::Allocator;
     use hyperactor_mesh::alloc::local::LocalAllocator;
     use hyperactor_mesh::proc_mesh::ProcMesh;
-    use ndslice::shape;
+    use ndslice::extent;
     use tempfile::TempDir;
     use tokio::fs;
     use tokio::net::TcpListener;
@@ -480,7 +480,7 @@ mod tests {
         // Set up actor mesh with 2 RsyncActors
         let alloc = LocalAllocator
             .allocate(AllocSpec {
-                shape: shape! { replica = 1 },
+                extent: extent! { replica = 1 },
                 constraints: Default::default(),
             })
             .await?;

--- a/monarch_hyperactor/tests/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/tests/code_sync/auto_reload.rs
@@ -17,7 +17,7 @@ use hyperactor_mesh::proc_mesh::ProcMesh;
 use monarch_hyperactor::code_sync::auto_reload::AutoReloadActor;
 use monarch_hyperactor::code_sync::auto_reload::AutoReloadMessage;
 use monarch_hyperactor::code_sync::auto_reload::AutoReloadParams;
-use ndslice::shape;
+use ndslice::extent;
 use pyo3::ffi::c_str;
 use pyo3::prelude::*;
 use tempfile::TempDir;
@@ -45,7 +45,7 @@ CONSTANT = "initial_constant"
     // Set up a single AutoReloadActor
     let alloc = LocalAllocator
         .allocate(AllocSpec {
-            shape: shape! { replica = 1 },
+            extent: extent! { replica = 1 },
             constraints: Default::default(),
         })
         .await?;

--- a/monarch_rdma/examples/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server.rs
@@ -79,8 +79,8 @@ use monarch_rdma::IbverbsConfig;
 use monarch_rdma::RdmaBuffer;
 use monarch_rdma::RdmaManagerActor;
 use monarch_rdma::RdmaManagerMessageClient;
+use ndslice::extent;
 use ndslice::selection;
-use ndslice::shape;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::process::Command;
@@ -474,7 +474,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     let ps_proc_mesh = ProcMesh::allocate(
         alloc
             .allocate(AllocSpec {
-                shape: shape! {replica=1, host=1, gpu=1},
+                extent: extent! {replica=1, host=1, gpu=1},
                 constraints: Default::default(),
             })
             .await?,
@@ -500,7 +500,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     let worker_proc_mesh = ProcMesh::allocate(
         alloc
             .allocate(AllocSpec {
-                shape: shape! {replica=1, host=1, gpu=num_workers},
+                extent: extent! {replica=1, host=1, gpu=num_workers},
                 constraints: Default::default(),
             })
             .await?,

--- a/monarch_rdma/src/test_utils.rs
+++ b/monarch_rdma/src/test_utils.rs
@@ -87,7 +87,7 @@ pub mod test_utils {
     use hyperactor_mesh::alloc::AllocSpec;
     use hyperactor_mesh::alloc::Allocator;
     use hyperactor_mesh::alloc::LocalAllocator;
-    use ndslice::shape;
+    use ndslice::extent;
 
     use crate::IbverbsConfig;
     use crate::PollTarget;
@@ -332,7 +332,7 @@ pub mod test_utils {
 
             let alloc_1 = LocalAllocator
                 .allocate(AllocSpec {
-                    shape: shape! { proc = 1 },
+                    extent: extent! { proc = 1 },
                     constraints: Default::default(),
                 })
                 .await
@@ -344,7 +344,7 @@ pub mod test_utils {
 
             let alloc_2 = LocalAllocator
                 .allocate(AllocSpec {
-                    shape: shape! { proc = 1 },
+                    extent: extent! { proc = 1 },
                     constraints: Default::default(),
                 })
                 .await
@@ -372,7 +372,6 @@ pub mod test_utils {
 
                     let mut dptr: cuda_sys::CUdeviceptr = std::mem::zeroed();
                     let mut handle: cuda_sys::CUmemGenericAllocationHandle = std::mem::zeroed();
-                    let /*mut*/ padded_size: usize;
 
                     let mut device: cuda_sys::CUdevice = std::mem::zeroed();
                     cu_check!(cuda_sys::cuDeviceGet(&mut device, device_str.1));
@@ -397,7 +396,7 @@ pub mod test_utils {
                     ));
 
                     // ensure our size is aligned
-                    padded_size = ((buffer_size - 1) / granularity + 1) * granularity;
+                    let /*mut*/ padded_size: usize = ((buffer_size - 1) / granularity + 1) * granularity;
                     assert!(padded_size == buffer_size);
 
                     cu_check!(cuda_sys::cuMemCreate(

--- a/ndslice/src/strategy.rs
+++ b/ndslice/src/strategy.rs
@@ -653,7 +653,7 @@ mod tests {
       #[test]
       fn rank_is_injective(extent in gen_extent(1..=4, 8)) {
         let mut seen = HashSet::new();
-        for point in extent.iter() {
+        for point in extent.points() {
           let rank = point.rank();
           prop_assert!(
             seen.insert(rank),
@@ -675,7 +675,7 @@ mod tests {
       #[test]
       fn rank_is_monotonic(extent in gen_extent(1..=4, 8)) {
         let mut last_rank = None;
-        for point in extent.iter() {
+        for point in extent.points() {
           let rank = point.rank();
           if let Some(prev) = last_rank {
             prop_assert!(prev < rank, "Rank not monotonic: {} >= {}", prev, rank);
@@ -694,8 +694,8 @@ mod tests {
     proptest! {
       #[test]
       fn rank_bounds(extent in gen_extent(1..=4, 8)) {
-        let len = extent.len();
-        for point in extent.iter() {
+        let len = extent.num_ranks();
+        for point in extent.points() {
           let rank = point.rank();
           prop_assert!(rank < len, "Rank {} out of bounds for extent of size {}", rank, len);
         }
@@ -714,7 +714,7 @@ mod tests {
     proptest! {
         #[test]
         fn rank_point_trip(extent in gen_extent(1..=4, 8)) {
-            for r in 0..extent.len() {
+            for r in 0..extent.num_ranks() {
                 let point = extent.point_of_rank(r).unwrap();
                 prop_assert_eq!(
                     point.rank(),


### PR DESCRIPTION
Summary:
This moves allocation away from being defined by their `Shape` to being defined by `Extent`s (and views of these).

Most of these changes are mechanical, with some opportunities to simplify taken along the way. There is still some additional cleanup to do before removing shapes entirely.

That will also need to be plumbed into the Python stack.

Differential Revision: D79618262


